### PR TITLE
fix: added option to override homepage

### DIFF
--- a/cli/src/lib/parseConfig.js
+++ b/cli/src/lib/parseConfig.js
@@ -52,6 +52,7 @@ const parseConfig = paths => {
 
         if (fs.existsSync(paths.package)) {
             config.name = config.name || require(paths.package).name
+            config.homepage = config.homepage || require(paths.package).homepage
         }
         config.title = config.title || config.name
 

--- a/cli/src/lib/shell/env.js
+++ b/cli/src/lib/shell/env.js
@@ -17,7 +17,9 @@ const prefixEnvForCRA = env =>
             ...out,
             [`REACT_APP_${key}`]: env[key],
         }),
-        {}
+        {
+            "PUBLIC_URL": env["DHIS2_APP_HOMEPAGE"]
+        }
     )
 
 const getDHISConfig = () => {

--- a/cli/src/lib/shell/index.js
+++ b/cli/src/lib/shell/index.js
@@ -16,7 +16,7 @@ module.exports = ({ config, paths }) => ({
             cmd: 'yarn',
             args: ['run', 'build'],
             cwd: paths.shell,
-            env: getEnv({ name: config.title }),
+            env: getEnv({ name: config.title, homepage: config.homepage }),
             pipe: true,
         })
     },


### PR DESCRIPTION
See #26 

Maybe it would be better to define a default value for the homepage so that if neither _package.json_ or _d2.config.js_ has that field we can use a default value instead of leaving it as undefined (which works since _react-scripts build_ ignores the value if undefined.