### PR TITLE
fix: remove publish-breaking comment from package.json

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -14,8 +14,8 @@
         "config",
         "src"
     ],
+    "//": "****** Includes standard libraries from app-shell, so that tests work ******",
     "dependencies": {
-        "//": "****** Includes standard libraries from app-shell, so that tests work ******",
         "@babel/core": "^7.6.0",
         "@babel/plugin-proposal-class-properties": "^7.4.4",
         "@babel/plugin-proposal-object-rest-spread": "^7.4.4",


### PR DESCRIPTION
Publishes have been silently failing (see dhis2/cli#131) since 1.2.0 because of the comment dependency in package.json.  I moved the comment out of the dependencies map, which should work fine.