### PR TITLE
fix: detect an occupied port and find an open one

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -30,6 +30,7 @@
         "babel-jest": "^24.9.0",
         "chalk": "^2.4.2",
         "classnames": "^2.2.6",
+        "detect-port": "^1.3.0",
         "dotenv": "^8.1.0",
         "dotenv-expand": "^5.1.0",
         "fs-extra": "^8.1.0",

--- a/cli/src/lib/shell/env.js
+++ b/cli/src/lib/shell/env.js
@@ -1,8 +1,5 @@
 const { reporter } = require('@dhis2/cli-helpers-engine')
 
-const defaultShellPort = 3000
-const getShellPort = () => process.env.PORT || defaultShellPort
-
 const filterEnv = () =>
     Object.keys(process.env)
         .filter(key => key.indexOf('DHIS2_') === 0)
@@ -32,18 +29,16 @@ const makeShellEnv = vars =>
         {}
     )
 
-module.exports = vars => {
+module.exports = ({ port, ...vars }) => {
     const env = {
         ...prefixEnvForCRA({
             ...filterEnv(),
             ...makeShellEnv(vars),
         }),
-        PORT: getShellPort(),
+        PORT: port,
         PUBLIC_URL: process.env.PUBLIC_URL,
     }
 
     reporter.debug('Env passed to app-shell:', env)
     return env
 }
-module.exports.defaultShellPort = defaultShellPort
-module.exports.getShellPort = getShellPort

--- a/docs/scripts/start.md
+++ b/docs/scripts/start.md
@@ -14,5 +14,6 @@ Options:
   --cwd       working directory to use (defaults to cwd)
   --version   Show version number                                      [boolean]
   --config    Path to JSON config file
+  --port, -p  The port to use when running the development server       [number]
   -h, --help  Show help                                                [boolean]
 ```

--- a/examples/simple-app/yarn.lock
+++ b/examples/simple-app/yarn.lock
@@ -927,7 +927,7 @@
   integrity sha512-rt2PZYZHwOq7qkkyczLYBgfReaENwauxx8iaTimTwdJrAXRUPkbhjlor63/00XgAY95tsZL7nMK7x3TwiSUfpQ==
 
 "@dhis2/cli-app-scripts@file:../../cli":
-  version "1.5.1"
+  version "1.5.3"
   dependencies:
     "@babel/core" "^7.6.2"
     "@babel/plugin-proposal-class-properties" "^7.4.4"

--- a/shell/adapter/yarn.lock
+++ b/shell/adapter/yarn.lock
@@ -863,7 +863,7 @@
   integrity sha512-rt2PZYZHwOq7qkkyczLYBgfReaENwauxx8iaTimTwdJrAXRUPkbhjlor63/00XgAY95tsZL7nMK7x3TwiSUfpQ==
 
 "@dhis2/cli-app-scripts@file:../../cli":
-  version "1.5.1"
+  version "1.5.3"
   dependencies:
     "@babel/core" "^7.6.2"
     "@babel/plugin-proposal-class-properties" "^7.4.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1416,6 +1416,11 @@ acorn@^7.0.0, acorn@^7.1.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
   integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
 
+address@^1.0.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/address/-/address-1.1.2.tgz#bf1116c9c758c51b7a933d296b72c221ed9428b6"
+  integrity sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==
+
 aggregate-error@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.0.0.tgz#5b5a3c95e9095f311c9ab16c19fb4f3527cd3f79"
@@ -2806,7 +2811,7 @@ date-fns@^1.27.2, date-fns@^1.30.1:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -2956,6 +2961,14 @@ detect-newline@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
   integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
+
+detect-port@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/detect-port/-/detect-port-1.3.0.tgz#d9c40e9accadd4df5cac6a782aefd014d573d1f1"
+  integrity sha512-E+B1gzkl2gqxt1IhUzwjrxBKRqx1UzC3WLONHinn8S3T6lwV/agVCyitiFOsGJ/eYuEUBvD71MZHy3Pv1G9doQ==
+  dependencies:
+    address "^1.0.1"
+    debug "^2.6.0"
 
 diff-sequences@^24.9.0:
   version "24.9.0"


### PR DESCRIPTION
This adds a `--port` switch to the `start` command and also corrects the behavior when the specified port (by CLI flag, env var, or default 3000) is occupied - instead of silently failing and waiting forever, it warns the user that the port is in use and selects the next available port sequentially to run the dev server.