### PR TITLE
fix: upgrade Headerbar to 2.0.1, don't break on older servers

### DIFF
--- a/examples/simple-app/yarn.lock
+++ b/examples/simple-app/yarn.lock
@@ -927,7 +927,7 @@
   integrity sha512-w5+C/fHSsuF0am5Tpvz53+tigEZzfz9ahkjXH3BiWxGVxwZGtdHjWfso1T5bJRiKhDTgf76TxIsQiC11W20WyA==
 
 "@dhis2/cli-app-scripts@file:../../cli":
-  version "1.5.6"
+  version "1.5.7"
   dependencies:
     "@babel/core" "^7.6.2"
     "@babel/plugin-proposal-class-properties" "^7.4.4"

--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
     "scripts": {
         "format": "d2-style js apply --all --no-stage",
         "install:example": "cd examples/simple-app && yarn install --force --check-files",
+        "install:shell": "cd shell && yarn",
         "build:adapter": "cd shell/adapter && yarn --force --check-files && yarn build",
         "build:cli": "cd cli && yarn build",
         "build:example": "cd examples/simple-app && yarn build --force",
-        "build": "yarn build:adapter && yarn build:cli && yarn install:example",
+        "build": "yarn build:adapter && yarn install:shell && yarn build:cli && yarn install:example",
         "start:example": "cd examples/simple-app && yarn start --force",
         "start": "yarn build && yarn start:example",
         "docs:serve": "d2-utils-docsite serve ./docs -o ./dist",

--- a/shell/adapter/package.json
+++ b/shell/adapter/package.json
@@ -9,7 +9,7 @@
     ],
     "dependencies": {
         "@dhis2/ui-core": "^3.12.0",
-        "@dhis2/ui-widgets": "^2.0.0",
+        "@dhis2/ui-widgets": "^2.0.1",
         "moment": "^2.24.0"
     },
     "devDependencies": {

--- a/shell/adapter/yarn.lock
+++ b/shell/adapter/yarn.lock
@@ -863,7 +863,7 @@
   integrity sha512-w5+C/fHSsuF0am5Tpvz53+tigEZzfz9ahkjXH3BiWxGVxwZGtdHjWfso1T5bJRiKhDTgf76TxIsQiC11W20WyA==
 
 "@dhis2/cli-app-scripts@file:../../cli":
-  version "1.5.6"
+  version "1.5.7"
   dependencies:
     "@babel/core" "^7.6.2"
     "@babel/plugin-proposal-class-properties" "^7.4.4"
@@ -949,16 +949,16 @@
     classnames "^2.2.6"
     styled-jsx "^3.2.2"
 
-"@dhis2/ui-widgets@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-widgets/-/ui-widgets-2.0.0.tgz#7c5e3511bc8685e05c2a9a647f3c387ebb0edc61"
-  integrity sha512-GVeYBGh6bBHC4AwHBAlp9emYXWsSq9LgDixYjhJ4wbiJ8cnzM3rHAB2mUcP9wt455RMmMyR7QNg6To1ZDm60Jg==
+"@dhis2/ui-widgets@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-widgets/-/ui-widgets-2.0.1.tgz#9c0a308ddaff265b6b06155f6838bfb7074b8183"
+  integrity sha512-Ncr+TORWdxylRnwjgoYtBjHsPozBTPMpt4lf/86mdH4RHnb1OaiDz6UXFApCjpwbxJBT6qf37z1dq2abV7Z3KQ==
   dependencies:
     "@dhis2/d2-i18n" "1.0.6"
     "@dhis2/ui-core" "3.12.0"
     classnames "^2.2.6"
     concurrently "^5.0.0"
-    styled-jsx "^3.2.3"
+    styled-jsx "^3.2.4"
     wait-on "^3.3.0"
 
 "@hapi/address@2.x.x":
@@ -2131,6 +2131,13 @@ convert-source-map@1.6.0, convert-source-map@^1.1.0, convert-source-map@^1.4.0, 
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
   integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
+  dependencies:
+    safe-buffer "~5.1.1"
+
+convert-source-map@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
+  integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
   dependencies:
     safe-buffer "~5.1.1"
 
@@ -6576,14 +6583,14 @@ styled-jsx@^3.2.2:
     stylis "3.5.4"
     stylis-rule-sheet "0.0.10"
 
-styled-jsx@^3.2.3:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-3.2.3.tgz#c3b160a0622c892485103d0fef855347d78b9b67"
-  integrity sha512-TvEaDN4ArhFHJSZPzsKXmOiCTqWP434NW4eJD4iaTI5g3zph1BdpJPhAoE6I6wO1F6uYNgJZdT4AC2QlunTGcQ==
+styled-jsx@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-3.2.4.tgz#cbcdedcfb81d717fd355c4a0d8443f8e74527b60"
+  integrity sha512-UMclQzI1lss38RhyjTf7SmtXJEMbB6Q9slDz8adGtzHjirYb1PPgeWLSP8SlZc8c9f3LF6axmtv+6K/553ANdg==
   dependencies:
     babel-plugin-syntax-jsx "6.18.0"
     babel-types "6.26.0"
-    convert-source-map "1.6.0"
+    convert-source-map "1.7.0"
     loader-utils "1.2.3"
     source-map "0.7.3"
     string-hash "1.1.3"

--- a/shell/yarn.lock
+++ b/shell/yarn.lock
@@ -974,7 +974,7 @@
   version "1.0.0"
   dependencies:
     "@dhis2/ui-core" "^3.12.0"
-    "@dhis2/ui-widgets" "^2.0.0"
+    "@dhis2/ui-widgets" "^2.0.1"
     moment "^2.24.0"
 
 "@dhis2/app-runtime@^2.0.4":
@@ -1006,16 +1006,16 @@
     classnames "^2.2.6"
     styled-jsx "^3.2.2"
 
-"@dhis2/ui-widgets@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-widgets/-/ui-widgets-2.0.0.tgz#7c5e3511bc8685e05c2a9a647f3c387ebb0edc61"
-  integrity sha512-GVeYBGh6bBHC4AwHBAlp9emYXWsSq9LgDixYjhJ4wbiJ8cnzM3rHAB2mUcP9wt455RMmMyR7QNg6To1ZDm60Jg==
+"@dhis2/ui-widgets@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-widgets/-/ui-widgets-2.0.1.tgz#9c0a308ddaff265b6b06155f6838bfb7074b8183"
+  integrity sha512-Ncr+TORWdxylRnwjgoYtBjHsPozBTPMpt4lf/86mdH4RHnb1OaiDz6UXFApCjpwbxJBT6qf37z1dq2abV7Z3KQ==
   dependencies:
     "@dhis2/d2-i18n" "1.0.6"
     "@dhis2/ui-core" "3.12.0"
     classnames "^2.2.6"
     concurrently "^5.0.0"
-    styled-jsx "^3.2.3"
+    styled-jsx "^3.2.4"
     wait-on "^3.3.0"
 
 "@hapi/address@2.x.x":
@@ -2888,6 +2888,13 @@ convert-source-map@1.6.0, convert-source-map@^1.1.0, convert-source-map@^1.4.0, 
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
   integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
+  dependencies:
+    safe-buffer "~5.1.1"
+
+convert-source-map@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
+  integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
   dependencies:
     safe-buffer "~5.1.1"
 
@@ -9733,7 +9740,7 @@ style-loader@1.0.0:
     loader-utils "^1.2.3"
     schema-utils "^2.0.1"
 
-styled-jsx@^3.2.2, styled-jsx@^3.2.3:
+styled-jsx@^3.2.2:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-3.2.3.tgz#c3b160a0622c892485103d0fef855347d78b9b67"
   integrity sha512-TvEaDN4ArhFHJSZPzsKXmOiCTqWP434NW4eJD4iaTI5g3zph1BdpJPhAoE6I6wO1F6uYNgJZdT4AC2QlunTGcQ==
@@ -9741,6 +9748,20 @@ styled-jsx@^3.2.2, styled-jsx@^3.2.3:
     babel-plugin-syntax-jsx "6.18.0"
     babel-types "6.26.0"
     convert-source-map "1.6.0"
+    loader-utils "1.2.3"
+    source-map "0.7.3"
+    string-hash "1.1.3"
+    stylis "3.5.4"
+    stylis-rule-sheet "0.0.10"
+
+styled-jsx@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-3.2.4.tgz#cbcdedcfb81d717fd355c4a0d8443f8e74527b60"
+  integrity sha512-UMclQzI1lss38RhyjTf7SmtXJEMbB6Q9slDz8adGtzHjirYb1PPgeWLSP8SlZc8c9f3LF6axmtv+6K/553ANdg==
+  dependencies:
+    babel-plugin-syntax-jsx "6.18.0"
+    babel-types "6.26.0"
+    convert-source-map "1.7.0"
     loader-utils "1.2.3"
     source-map "0.7.3"
     string-hash "1.1.3"


### PR DESCRIPTION
Also fixes the build process to ensure `shell/yarn.lock` is correctly updated