### PR TITLE
fix: use Provider instead of DataProvider

### DIFF
--- a/examples/simple-app/yarn.lock
+++ b/examples/simple-app/yarn.lock
@@ -927,7 +927,7 @@
   integrity sha512-w5+C/fHSsuF0am5Tpvz53+tigEZzfz9ahkjXH3BiWxGVxwZGtdHjWfso1T5bJRiKhDTgf76TxIsQiC11W20WyA==
 
 "@dhis2/cli-app-scripts@file:../../cli":
-  version "1.5.7"
+  version "1.5.8"
   dependencies:
     "@babel/core" "^7.6.2"
     "@babel/plugin-proposal-class-properties" "^7.4.4"

--- a/shell/adapter/src/index.js
+++ b/shell/adapter/src/index.js
@@ -1,15 +1,15 @@
 import React from 'react'
 import { HeaderBar } from '@dhis2/ui-widgets'
-import { DataProvider } from '@dhis2/app-runtime'
+import { Provider } from '@dhis2/app-runtime'
 import { FatalErrorBoundary } from './FatalErrorBoundary'
 import { AuthBoundary } from './AuthBoundary'
 
 const App = ({ url, apiVersion, appName, children }) => (
     <FatalErrorBoundary>
-        <DataProvider baseUrl={url} apiVersion={apiVersion}>
+        <Provider config={{ baseUrl: url, apiVersion: apiVersion }}>
             <HeaderBar appName={appName} />
             <AuthBoundary url={url}>{children}</AuthBoundary>
-        </DataProvider>
+        </Provider>
     </FatalErrorBoundary>
 )
 

--- a/shell/adapter/yarn.lock
+++ b/shell/adapter/yarn.lock
@@ -863,7 +863,7 @@
   integrity sha512-w5+C/fHSsuF0am5Tpvz53+tigEZzfz9ahkjXH3BiWxGVxwZGtdHjWfso1T5bJRiKhDTgf76TxIsQiC11W20WyA==
 
 "@dhis2/cli-app-scripts@file:../../cli":
-  version "1.5.7"
+  version "1.5.8"
   dependencies:
     "@babel/core" "^7.6.2"
     "@babel/plugin-proposal-class-properties" "^7.4.4"


### PR DESCRIPTION
We mistakenly only rendered a DataProvider, which meant that the `useContext` hook returned invalid information (`baseUrl: '..'`) instead of being initialized by the app shell.