### PR TITLE
fix: add an eslint config to shell, falling back to react-app defaults

### DIFF
--- a/shell/.eslintrc.js
+++ b/shell/.eslintrc.js
@@ -1,0 +1,13 @@
+const fs = require('fs'),
+    path = require('path')
+
+const customConfigFile = path.resolve('../../.eslintrc.js')
+const hasCustomConfig = fs.existsSync(customConfigFile)
+
+const extendsArray = hasCustomConfig
+    ? [require(customConfigFile)]
+    : ['react-app']
+
+module.exports = {
+    extends: extendsArray,
+}


### PR DESCRIPTION
Fixes #197

This adds an eslint config to the shell root which will automatically detect a top-level `.eslintrc.js` file and load it, or will use `react-app` as a fallback.