### PR TITLE
fix: resolve the absolute path to the current directory

### DIFF
--- a/cli/config/babel.config.js
+++ b/cli/config/babel.config.js
@@ -1,11 +1,15 @@
+const path = require('path')
+
 const browserTargets = require('./.browserlistrc')
 const jestTargets = { node: 'current' }
 
 const isTest = process.env.NODE_ENV === 'test'
 const targets = isTest ? jestTargets : browserTargets
 
+const appBabelConfig = path.resolve(__dirname, 'app.babel.config')
+
 module.exports = {
-    extends: './app.babel.config',
+    extends: appBabelConfig,
     presets: [
         require('@babel/preset-react'),
         require('@babel/preset-typescript'),


### PR DESCRIPTION
When running `cli-app-scripts test` in an app, the line:

    extends: './app.babel.config'

Incorrectly resolves from the current working directory:

    Cannot find module './app.babel.config' from '/home/varl/dev/dhis2/apps/usage-analytics'

We can use `path.resolve` + `__dirname`[1] to resolve the absolute path
of the `app.babel.config.js` file relatively to `babel.config.js`.

[1] https://nodejs.org/api/globals.html#globals_dirname