### PR TITLE
fix: don't generate useless empty files if no translatable strings found

### DIFF
--- a/cli/src/commands/i18n.js
+++ b/cli/src/commands/i18n.js
@@ -1,4 +1,4 @@
-const { namespace } = require('@dhis2/cli-helpers-engine')
+const { namespace, reporter } = require('@dhis2/cli-helpers-engine')
 const i18n = require('../lib/i18n')
 
 const generate = {
@@ -19,15 +19,21 @@ const generate = {
         namespace: {
             alias: 'n',
             description: 'Namespace for app locale separation',
-            required: true,
+            default: 'default',
         },
     },
     handler: async argv => {
-        await i18n.generate({
+        const result = await i18n.generate({
             input: argv.path,
             output: argv.output,
             namespace: argv.namespace,
         })
+
+        if (!result) {
+            reporter.error('Failed to generate i18n code.')
+            process.exit(1)
+        }
+        reporter.info(`Done!`)
     },
 }
 const extract = {
@@ -46,7 +52,15 @@ const extract = {
         },
     },
     handler: async argv => {
-        await i18n.extract({ input: argv.path, output: argv.output })
+        const result = await i18n.extract({
+            input: argv.path,
+            output: argv.output,
+        })
+        if (!result) {
+            reporter.error('Failed to extract i18n strings.')
+            process.exit(1)
+        }
+        reporter.info(`Done!`)
     },
 }
 

--- a/cli/src/lib/i18n/generate.js
+++ b/cli/src/lib/i18n/generate.js
@@ -1,10 +1,10 @@
 const fs = require('fs-extra')
 const path = require('path')
-const { reporter } = require('@dhis2/cli-helpers-engine')
+const { reporter, chalk } = require('@dhis2/cli-helpers-engine')
 const { gettextToI18next } = require('i18next-conv')
 const handlebars = require('handlebars')
 
-const { ensureDirectoryExists } = require('./helpers')
+const { checkDirectoryExists } = require('./helpers')
 const { langToLocale } = require('./locales')
 
 const writeTemplate = (outFile, data) => {
@@ -17,7 +17,15 @@ const writeTemplate = (outFile, data) => {
 }
 
 const generate = async ({ input, output, namespace }) => {
-    ensureDirectoryExists(input)
+    if (!checkDirectoryExists(input)) {
+        const relativeInput = './' + path.relative(process.cwd(), input)
+        reporter.debug(
+            `Source directory ${chalk.bold(
+                relativeInput
+            )} does not exist, skipping i18n generation`
+        )
+        return false
+    }
 
     // clean-up and create destination dir.
     const dst = path.normalize(output)
@@ -58,6 +66,7 @@ const generate = async ({ input, output, namespace }) => {
     })
 
     await Promise.all(promises)
+    return true
 }
 
 module.exports = generate

--- a/cli/src/lib/i18n/helpers.js
+++ b/cli/src/lib/i18n/helpers.js
@@ -4,21 +4,22 @@ const path = require('path')
 
 const supportedExtensions = ['.js', '.jsx', '.ts', '.tsx']
 
-module.exports.ensureDirectoryExists = dir => {
+module.exports.checkDirectoryExists = dir => {
     const dirPath = path.normalize(dir)
     try {
         const stat = fs.lstatSync(dirPath)
 
         if (!stat.isDirectory()) {
-            reporter.error(
+            reporter.debugErr(
                 `Directory ${chalk.bold(dirPath)} is not a directory.`
             )
-            process.exit(1)
+            return false
         }
     } catch (e) {
-        reporter.error(`Directory ${chalk.bold(dirPath)} does not exist.`)
-        process.exit(1)
+        reporter.debugErr(`Directory ${chalk.bold(dirPath)} does not exist.`)
+        return false
     }
+    return true
 }
 
 // src from component/array-equal


### PR DESCRIPTION
Fixes #268 

This also cleans up some of the i18n code that was ported from the `d2-i18n-[extract|generate]` libraries