### PR TITLE
fix(cli-app-scripts): use the same build dir for modes

### DIFF
--- a/cli/src/lib/compiler/compileLibrary.js
+++ b/cli/src/lib/compiler/compileLibrary.js
@@ -24,10 +24,7 @@ const compileLibrary = async ({ config, paths, mode, watch }) => {
     const input =
         (config.entryPoints && config.entryPoints[config.type]) ||
         'src/index.js'
-    const outDir = mode === 'production' ? paths.buildOutput : paths.devOut
-
-    fs.removeSync(outDir)
-    fs.ensureDirSync(outDir)
+    const outDir = paths.buildOutput
 
     const pkg = require(paths.package)
 
@@ -50,6 +47,9 @@ const compileLibrary = async ({ config, paths, mode, watch }) => {
     reporter.debug('Rollup config', rollupConfig)
 
     if (!watch) {
+        fs.removeSync(outDir)
+        fs.ensureDirSync(outDir)
+
         // create a bundle
         try {
             const bundle = await rollup.rollup(rollupConfig)
@@ -81,6 +81,8 @@ const compileLibrary = async ({ config, paths, mode, watch }) => {
             process.exit(1)
         }
     } else {
+        fs.ensureDirSync(outDir)
+
         return new Promise((resolve, reject) => {
             reporter.debug('watching...')
             const watcher = rollup.watch({

--- a/cli/src/lib/paths.js
+++ b/cli/src/lib/paths.js
@@ -35,7 +35,6 @@ module.exports = (cwd = process.cwd()) => {
         i18nLocales: path.join(base, './src/locales'),
 
         d2: path.join(base, './.d2/'),
-        devOut: path.join(base, './.d2/devOut'),
         appOutputFilename: 'App.js',
         shell: path.join(base, './.d2/shell'),
         shellAppEntrypoint: path.join(base, './.d2/shell/src/App.js'),


### PR DESCRIPTION
This removes the devOut path and usage of it, instead opting for
building the development build and production build into the same
folder: ./build.

For libraries in monorepo situations this is important as they will look
up the main or module key in the package.json file, which is usually set
to e.g. ./build/{cjs,es}/lib.js when using the cli-app-scripts to build
the lib.