### PR TITLE
fix: height in safari (DHIS2-8277)

### DIFF
--- a/adapter/src/styles.js
+++ b/adapter/src/styles.js
@@ -11,5 +11,6 @@ export const styles = css`
     div.app-shell-app {
         flex: 1 1 auto;
         overflow: auto;
+        height: 100%;
     }
 `


### PR DESCRIPTION
Fixes the height issue in Safari for DV (https://jira.dhis2.org/browse/DHIS2-8277) by explicitly setting the height of the app to `100%`.

Correct height:
![image](https://user-images.githubusercontent.com/12590483/74956115-ea423a80-5405-11ea-856d-6f37363e487f.png)
