### PR TITLE
fix: explicitly include styled-jsx as cli dependency

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -54,7 +54,8 @@
         "rollup-plugin-node-resolve": "^5.0.1",
         "rollup-plugin-postcss": "^2.0.3",
         "rollup-plugin-replace": "^2.2.0",
-        "rollup-plugin-visualizer": "^3.2.2"
+        "rollup-plugin-visualizer": "^3.2.2",
+        "styled-jsx": "^3.2.5"
     },
     "bin": {
         "d2-app-scripts": "./bin/d2-app-scripts"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1073,7 +1073,7 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.4", "@babel/types@^7.8.3":
+"@babel/types@7.8.3", "@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.4", "@babel/types@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.8.3.tgz#5a383dffa5416db1b73dedffd311ffd0788fb31c"
   integrity sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==
@@ -12755,6 +12755,20 @@ styled-jsx@^3.2.2:
   dependencies:
     babel-plugin-syntax-jsx "6.18.0"
     babel-types "6.26.0"
+    convert-source-map "1.7.0"
+    loader-utils "1.2.3"
+    source-map "0.7.3"
+    string-hash "1.1.3"
+    stylis "3.5.4"
+    stylis-rule-sheet "0.0.10"
+
+styled-jsx@^3.2.5:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-3.2.5.tgz#0172a3e13a0d6d8bf09167dcaf32cf7102d932ca"
+  integrity sha512-prEahkYwQHomUljJzXzrFnBmQrSMtWOBbXn8QeEkpfFkqMZQGshxzzp4H8ebBIsbVlHF/3+GSXMnmK/fp7qVYQ==
+  dependencies:
+    "@babel/types" "7.8.3"
+    babel-plugin-syntax-jsx "6.18.0"
     convert-source-map "1.7.0"
     loader-utils "1.2.3"
     source-map "0.7.3"


### PR DESCRIPTION
`styled-jsx` needs to be included as a dependency of `d2-app-scripts` to support styled-jsx babel transpilation - in some cases, it isn't properly hoisted from app-shell.