### PR TITLE
fix: allow login username or password to be shorter than 4 chars

### DIFF
--- a/adapter/src/AuthBoundary/LoginModal.js
+++ b/adapter/src/AuthBoundary/LoginModal.js
@@ -19,7 +19,7 @@ export const LoginModal = () => {
     const [password, setPassword] = useState('')
     const [isDirty, setIsDirty] = useState(false)
 
-    const isValid = val => val && val.length > 3
+    const isValid = val => val && val.length >= 2
 
     const onSubmit = async e => {
         e.preventDefault()


### PR DESCRIPTION
On the DHIS2 user registration page we require a minimum of 4 characters when selecting a username.  However, in the user management app the minimum is 2 characters.

![Screen Shot 2020-03-20 at 10 29 12 PM](https://user-images.githubusercontent.com/947888/77207722-66f63080-6afa-11ea-87e0-85bb85384fe8.png)

This change allows users created in the latter interface to log in through the AppShell login dialog.