### PR TITLE
docs: adds the article with the Application Platform overview

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-The Application Platform provides common build system, development tools, runtime support, and standard functionality for DHIS2 applications. The basic features of a modern, compliant, and functional application are all provided out-of-the-box.
+The Application Platform provides common build system, development tools, runtime support, and standard functionality for DHIS2 applications. The basic features of a modern, compliant, and functional application are all provided out-of-the-box. For a short deep dive into the Application Platform you can read [this artile](https://developers.dhis2.org/2019/07/what-is-this-app-platform/).
 
 ![Empty application shell](./images/empty-shell.gif)
 


### PR DESCRIPTION
Hi 👋- hope you all having a good day! 

I am opening this little PR where I am adding a sentence that prompts the reader to the deep dive article from the developers docs. 

After reading the docs for the first time and as someone who never heard of the term application platform before I had the feeling that I didnt grasp the idea very well. I find that this article has a very good and short overview of what the Application Platform is, how it works and how can someone use it. 

This PR has no issue related to it but it emerged after a talk I had with @amcgee. Let me know your thoughts on this and your feedback.