### PR TITLE
fix: correctly detect changes in i18n string extraction

### DIFF
--- a/cli/src/lib/i18n/helpers.js
+++ b/cli/src/lib/i18n/helpers.js
@@ -24,7 +24,7 @@ module.exports.checkDirectoryExists = dir => {
 
 // src from component/array-equal
 module.exports.arrayEqual = (arr1, arr2) =>
-    arr1.length === arr2.length && arr1.some((item, idx) => item === arr2[idx])
+    arr1.length === arr2.length && arr1.every((item, idx) => item === arr2[idx])
 
 function walkDirectory(dirPath, files = []) {
     const list = fs.readdirSync(dirPath)


### PR DESCRIPTION
Key differences were being incorrectly detected, using `some` instead of `all` - this resulted in change detection only when the **number** of strings changed, rather than the content of any of those keys.