### PR TITLE
fix: support typescript source files in library builds

### DIFF
--- a/cli/config/babel.config.js
+++ b/cli/config/babel.config.js
@@ -4,7 +4,6 @@ const browserTargets = require('./.browserlistrc')
 const jestTargets = { node: 'current' }
 
 const isTest = process.env.NODE_ENV === 'test'
-const targets = isTest ? jestTargets : browserTargets
 
 const appBabelConfig = path.resolve(__dirname, 'app.babel.config')
 
@@ -16,8 +15,8 @@ module.exports = {
         [
             require('@babel/preset-env'),
             {
-                modules: 'auto',
-                targets,
+                modules: isTest ? 'commonjs' : 'auto',
+                targets: isTest ? jestTargets : browserTargets,
             },
         ],
     ],

--- a/cli/config/rollup.config.js
+++ b/cli/config/rollup.config.js
@@ -10,6 +10,7 @@ const replace = require('rollup-plugin-replace')
 const visualize = require('rollup-plugin-visualizer')
 
 const { reporter, chalk } = require('@dhis2/cli-helpers-engine')
+const extensions = ['.js', '.jsx', '.ts', '.tsx']
 
 const standardLibs = require('@dhis2/app-shell/package.json').dependencies
 
@@ -66,10 +67,6 @@ const bundle = ({
                 autoModules: false,
             }),
             json(),
-            babel({
-                configFile: require.resolve('./babel.config.js'),
-                exclude: /node_modules/, // only transpile our source code
-            }),
             resolve({
                 /*
                  * TODO: Use of named exports (particularly `react-is` from `react-redux`)
@@ -79,8 +76,15 @@ const bundle = ({
                  * See https://github.com/rollup/rollup-plugin-commonjs/issues/211#issuecomment-337897124
                  */
                 mainFields: ['browser', 'main'],
+                include: ['src/**/*'],
+                extensions,
             }),
             commonjs({ include: /node_modules/ }),
+            babel({
+                extensions,
+                configFile: require.resolve('./babel.config.js'),
+                exclude: /node_modules/, // only transpile our source code
+            }),
             visualize({
                 filename: path.join(outDir, 'stats.html'),
                 title: 'DHIS2 Build Analysis',


### PR DESCRIPTION
Typescript was supported in the compiler, but not in rollup so it didn't work for libraries.  Eventually we may want to include the default tsconfig.json here, but for the moment only https://github.com/dhis2/app-runtime uses it.