### PR TITLE
fix: keep default values that may have been set

### DIFF
--- a/cli/src/lib/i18n/extract.js
+++ b/cli/src/lib/i18n/extract.js
@@ -39,8 +39,9 @@ const extract = async ({ input, output }) => {
 
     var parsed = parser.get()
     var en = {}
-    Object.keys(parsed.en.translation)
-        .forEach(str => (en[str] = parsed.en.translation[str]))
+    Object.keys(parsed.en.translation).forEach(
+        str => (en[str] = parsed.en.translation[str])
+    )
 
     if (Object.keys(en).length === 0) {
         reporter.print(

--- a/cli/src/lib/i18n/extract.js
+++ b/cli/src/lib/i18n/extract.js
@@ -39,7 +39,8 @@ const extract = async ({ input, output }) => {
 
     var parsed = parser.get()
     var en = {}
-    Object.keys(parsed.en.translation).forEach(str => (en[str] = ''))
+    Object.keys(parsed.en.translation)
+        .forEach(str => (en[str] = parsed.en.translation[str]))
 
     if (Object.keys(en).length === 0) {
         reporter.print(


### PR DESCRIPTION
The i18next-scanner parser will set default values for a string if they are provided (including for plurals). 

This fix will copy any default values into the json that is used to generate the en.pot file.

Then we can have code in our apps like this:
```
const likes = i18n.t(
    '{{count}} likes',
    { 
        count: numLikes,
        defaultValue: '{{count}} like',
        defaultValue_plural: '{{count}} likes'
    });
```

This results in the following in the en.pot file:
```
msgid "{{count}} likes"
msgid_plural "{{count}} likes"
msgstr[0] "{{count}} like"
msgstr[1] "{{count}} likes"
```

Ultimately in the app, we end up with these strings: `1 like` and `2 likes` as default.