### PR TITLE
fix: fix erroneous call to reporter.debugError

### DIFF
--- a/cli/src/lib/compiler/compileApp.js
+++ b/cli/src/lib/compiler/compileApp.js
@@ -72,7 +72,7 @@ const watchFiles = ({ inputDir, outputDir, processFileCallback, watch }) => {
             .on('change', compileFile)
             .on('unlink', removeFile)
             .on('error', error => {
-                reporter.debugError('Chokidar error:', error)
+                reporter.debugErr('Chokidar error:', error)
                 reject('Chokidar error!')
             })
 


### PR DESCRIPTION
Should be `reporter.debugErr`, see https://github.com/dhis2/cli-helpers-engine/blob/v1.5.0/lib/reporter.js#L29