### PR TITLE
feat: add core_app flag to app manifest

### DIFF
--- a/cli/src/lib/generateManifest.js
+++ b/cli/src/lib/generateManifest.js
@@ -8,6 +8,7 @@ module.exports = (paths, config, publicUrl) => {
         name: config.title,
         description: config.description,
         version: config.version,
+        core_app: config.coreApp,
         launch_path: 'index.html',
         default_locale: 'en',
         activities: {


### PR DESCRIPTION
Relates to dhis2/dhis2-core#6111 - add `core_app` flag to `manifest.webapp` so that the Core knows it is an intentional override.