### PR TITLE
fix: base url should be overridden with env var if present

### DIFF
--- a/cli/src/commands/build.js
+++ b/cli/src/commands/build.js
@@ -37,8 +37,9 @@ const setAppParameters = (standalone, config) => {
         standalone === false ||
         (typeof standalone === 'undefined' && !config.standalone)
     ) {
-        process.env.DHIS2_BASE_URL =
-            process.env.DHIS2_BASE_URL || config.coreApp ? `..` : `../../..`
+        const defaultBase = config.coreApp ? `..` : `../../..`
+        process.env.DHIS2_BASE_URL = process.env.DHIS2_BASE_URL || defaultBase
+
         printBuildParam('DHIS2_BASE_URL', process.env.DHIS2_BASE_URL)
     } else {
         printBuildParam('DHIS2_BASE_URL', '<standalone>')


### PR DESCRIPTION
Closes #458 

I looked around, but this seems to be the only place where this pattern was used. I chose a separate var instead of using parentheses to clarify the intent, so that later on someone doesn't accidentally remove the parentheses.