### PR TITLE
feat: generate d2.config.json from d2.config.js

### DIFF
--- a/cli/src/lib/generateManifest.js
+++ b/cli/src/lib/generateManifest.js
@@ -32,5 +32,12 @@ module.exports = (paths, config, publicUrl) => {
 
     reporter.debug('Generated manifest', manifest)
 
+    // For backwards compatibility, WILL BE DEPRECATED
     fs.writeJsonSync(paths.buildAppManifest, manifest, { spaces: 2 })
+
+    // Write config json
+    const appConfig = { ...config }
+    delete appConfig['entryPoints']
+
+    fs.writeJsonSync(paths.buildAppConfigJson, appConfig, { spaces: 2 })
 }

--- a/cli/src/lib/paths.js
+++ b/cli/src/lib/paths.js
@@ -48,6 +48,7 @@ module.exports = (cwd = process.cwd()) => {
         buildOutput: path.join(base, './build'),
         buildAppOutput: path.join(base, './build/app'),
         buildAppManifest: path.join(base, './build/app/manifest.webapp'),
+        buildAppConfigJson: path.join(base, './build/app/d2.config.json'),
         buildAppBundle: path.join(
             base,
             './build/bundle/dhis2-{{name}}-{{version}}.zip'


### PR DESCRIPTION
This generates a new config file `d2.config.json` from the compiled [application config](https://platform.dhis2.nu/#/config/d2-config-js-reference) (merge of `package.json` and `d2.config.js`).  The `.json` file is placed at the root of the application output, next to `manifest.webapp`, which it will eventually replace.  The data in this config file is necessary to enforce immutable application slugs, parse version numbers, and other things when publishing to the App Hub.

Here is a sample `d2.config.json` output generated from `examples/simple-app` :

```json
{
  "name": "simple-app",
  "title": "Simple Example App",
  "description": "This is a simple example application",
  "standalone": true,
  "type": "app",
  "version": "1.0.0",
  "author": {
    "name": "Austin McGee",
    "email": "austin@dhis2.org"
  }
}
```