### PR TITLE
chore: bump @dhis2/ui to latest

### DIFF
--- a/shell/package.json
+++ b/shell/package.json
@@ -15,7 +15,7 @@
         "@dhis2/app-adapter": "5.5.1",
         "@dhis2/app-runtime": "^2.6.1",
         "@dhis2/d2-i18n": "^1.0.5",
-        "@dhis2/ui": "^5.7.2",
+        "@dhis2/ui": "^6.1.6",
         "classnames": "^2.2.6",
         "moment": "^2.24.0",
         "prop-types": "^15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2364,59 +2364,59 @@
   dependencies:
     prop-types "^15"
 
-"@dhis2/ui-constants@5.7.3":
-  version "5.7.3"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-constants/-/ui-constants-5.7.3.tgz#6c484133fdb17e0b71ddb6d621c472b510b3093f"
-  integrity sha512-bs7Y9KPtC/7z9usIUSJxtNqNMGW3f1gZ3tYqGdHnPNknr3RyKPVzgF9VH8r5bNVZUJqSN4EbwtjB2i53EsNHFA==
+"@dhis2/ui-constants@6.1.6":
+  version "6.1.6"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-constants/-/ui-constants-6.1.6.tgz#2249ff9ef01fe3bb70c4661368c98e51a85b561e"
+  integrity sha512-xr65KPtx1XD97fpkYnaXOXJdhdZ0dnJZBkccqtBqJVq2eRKjyZq5AfXjsdquaDDNJx1Ljh342qG3WnXfeDx+iA==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
 
-"@dhis2/ui-core@5.7.3":
-  version "5.7.3"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-5.7.3.tgz#0b20723de22b1ac2ef4a7d9a91bd909573d044a8"
-  integrity sha512-2kP/D61amgCrr0FZZBTniWLGLCdMlQbQxAC7WCP1NVYufFmIHcjLyRvhGLZbHfqsFppHF0CNiQOxZB6oKI3gvg==
+"@dhis2/ui-core@6.1.6":
+  version "6.1.6"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-6.1.6.tgz#4c12f9d4ee8bf950820a49c39fb951fb8fd1d72c"
+  integrity sha512-G5ZWpDUF0ZPhhJi2cGpBqxZ0jqQikB2skQ4LjbuV3mKf+9IfHR+JYBmKxmLPkJc2uiEExXQWFDIONOJG+BJpuw==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
-    "@popperjs/core" "^2.5.3"
+    "@popperjs/core" "^2.6.0"
     classnames "^2.2.6"
     react-popper "^2.2.3"
     resize-observer-polyfill "^1.5.1"
 
-"@dhis2/ui-forms@5.7.3":
-  version "5.7.3"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-forms/-/ui-forms-5.7.3.tgz#cb84339089234d9565654937611fd70dbacdd9c9"
-  integrity sha512-sKBvolbcffC01+t1krDrA2y8oEmsenkLSFi6AyXmQN8M8YD2x8SECoJILLGUVVaeMXQ81tvgFzfnjh1XZjaI4A==
+"@dhis2/ui-forms@6.1.6":
+  version "6.1.6"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-forms/-/ui-forms-6.1.6.tgz#2980154dea701651a3f6a6b1b541a88b33722fcb"
+  integrity sha512-5sfMFAY7It1kj+YvFHkXmcXzLW6KzxBVib8NNtCfMH5WYPtX7i5aV1u3J47iQWSx9IjKnj0sauTRVjljY5Zr6Q==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
     classnames "^2.2.6"
     final-form "^4.20.1"
     react-final-form "^6.5.1"
 
-"@dhis2/ui-icons@5.7.3":
-  version "5.7.3"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-5.7.3.tgz#d6df117b0001a405caa874d5f887c4f088bc1357"
-  integrity sha512-UGBhF41JmVrZcz2Acliv7TCJhTP1tu7zv3iQQgzm9QG4iwXj6sD0veiLgOUwenw12gqPcv0HfErqjigYflyVLw==
+"@dhis2/ui-icons@6.1.6":
+  version "6.1.6"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-6.1.6.tgz#31be3d2d7b0dd34ccae30591f4ba8f3417b0b50e"
+  integrity sha512-nLKmaxfYPBI/fZCBbplq4bTrzuQljrJ91s3bwdjpQFxLSgwPHwSvxBKFn2H5s3rQ4EJBWSTkzmbvPLMG6XiBkQ==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
 
-"@dhis2/ui-widgets@5.7.3":
-  version "5.7.3"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-widgets/-/ui-widgets-5.7.3.tgz#89fdb5a693968da53cb673df22d27dee7bec8164"
-  integrity sha512-J5xHpR502/yi+mZl4x19PxlRnFlcparIgICD0FuAhwWazbjWKi2xJr3fcff2kej+qWdPQx+oum2d4UYPfkUOCg==
+"@dhis2/ui-widgets@6.1.6":
+  version "6.1.6"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-widgets/-/ui-widgets-6.1.6.tgz#fb8c46393ba65bfb3def29b62c6a78a20754661f"
+  integrity sha512-W7grziyGX/S6t6l1zSFixBaKr+Ny4OgAFUwklUm7LjAqAgShq1vG+AmqFzcH1TUaLlr4AkvpYAgz+TljVwa4ew==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
     classnames "^2.2.6"
 
-"@dhis2/ui@^5.7.2":
-  version "5.7.3"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-5.7.3.tgz#78c6abdf2482a9ebb487f6d6666111a59f4ebb06"
-  integrity sha512-MXc9JxTJ5Z9tmDJbzNKsjcTJfvUWkypdTV2fGmaMpx3HInx+w8Y3FhivUrcsFXtpARmG/58YerWwYZaWS0OyBQ==
+"@dhis2/ui@^6.1.6":
+  version "6.1.6"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-6.1.6.tgz#4f8792faebd5f7d0864152f02d20bee316e19e0f"
+  integrity sha512-vhlj8SCCGZ4a0l1m54vdrLO75Clwx3wPG9231D3wkf2xVDx5JQS83wZ5f3gENzqB3Mtvfb+8hQOuF8T5gD+vJg==
   dependencies:
-    "@dhis2/ui-constants" "5.7.3"
-    "@dhis2/ui-core" "5.7.3"
-    "@dhis2/ui-forms" "5.7.3"
-    "@dhis2/ui-icons" "5.7.3"
-    "@dhis2/ui-widgets" "5.7.3"
+    "@dhis2/ui-constants" "6.1.6"
+    "@dhis2/ui-core" "6.1.6"
+    "@dhis2/ui-forms" "6.1.6"
+    "@dhis2/ui-icons" "6.1.6"
+    "@dhis2/ui-widgets" "6.1.6"
 
 "@eslint/eslintrc@^0.2.1":
   version "0.2.1"
@@ -2857,10 +2857,10 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
-"@popperjs/core@^2.5.3":
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.5.4.tgz#de25b5da9f727985a3757fd59b5d028aba75841a"
-  integrity sha512-ZpKr+WTb8zsajqgDkvCEWgp6d5eJT6Q63Ng2neTbzBO76Lbe91vX/iVIW9dikq+Fs3yEo+ls4cxeXABD2LtcbQ==
+"@popperjs/core@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.6.0.tgz#f022195afdfc942e088ee2101285a1d31c7d727f"
+  integrity sha512-cPqjjzuFWNK3BSKLm0abspP0sp/IGOli4p5I5fKFAzdS8fvjdOwDCfZqAaIiXd9lPkOWi3SUUfZof3hEb7J/uw==
 
 "@rollup/plugin-node-resolve@^7.1.1":
   version "7.1.3"


### PR DESCRIPTION
Bumps `@dhis2/ui` to the latest version, [`^6.1.6`](https://github.com/dhis2/ui/releases/tag/v6.1.6)