### PR TITLE
fix: pin styled-jsx@3.3.2 to avoid styled-jsx/babel bug

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -61,7 +61,7 @@
         "rollup-plugin-postcss": "^2.0.3",
         "rollup-plugin-replace": "^2.2.0",
         "rollup-plugin-visualizer": "^3.2.2",
-        "styled-jsx": "^3.2.5"
+        "styled-jsx": "<3.3.3"
     },
     "bin": {
         "d2-app-scripts": "./bin/d2-app-scripts"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15236,7 +15236,21 @@ style-loader@1.3.0:
     loader-utils "^2.0.0"
     schema-utils "^2.7.0"
 
-styled-jsx@^3.2.2, styled-jsx@^3.2.5:
+styled-jsx@<3.3.3:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-3.3.2.tgz#2474601a26670a6049fb4d3f94bd91695b3ce018"
+  integrity sha512-daAkGd5mqhbBhLd6jYAjYBa9LpxYCzsgo/f6qzPdFxVB8yoGbhxvzQgkC0pfmCVvW3JuAEBn0UzFLBfkHVZG1g==
+  dependencies:
+    "@babel/types" "7.8.3"
+    babel-plugin-syntax-jsx "6.18.0"
+    convert-source-map "1.7.0"
+    loader-utils "1.2.3"
+    source-map "0.7.3"
+    string-hash "1.1.3"
+    stylis "3.5.4"
+    stylis-rule-sheet "0.0.10"
+
+styled-jsx@^3.2.2:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-3.2.5.tgz#0172a3e13a0d6d8bf09167dcaf32cf7102d932ca"
   integrity sha512-prEahkYwQHomUljJzXzrFnBmQrSMtWOBbXn8QeEkpfFkqMZQGshxzzp4H8ebBIsbVlHF/3+GSXMnmK/fp7qVYQ==


### PR DESCRIPTION
There is an open [bug in styled-jsx/babel](https://github.com/vercel/styled-jsx/issues/695) introduced in 3.3.3 which causes invalid js output.  Until that issue is fixed, pin our version of styled-jsx to 3.3.2 (for compilation, runtime can still track later versions)