### PR TITLE
fix: namespace code-split moment locale chunks to separate them from app chunks

### DIFF
--- a/adapter/src/utils/useLocale.js
+++ b/adapter/src/utils/useLocale.js
@@ -14,7 +14,9 @@ const simplifyLocale = locale => {
 
 const setGlobalLocale = locale => {
     if (locale !== 'en' && locale !== 'en-us') {
-        import(`moment/locale/${locale}`).catch(() => {
+        import(
+            /* webpackChunkName: "moment-locales/[request]" */ `moment/locale/${locale}`
+        ).catch(() => {
             /* ignore */
         })
     }


### PR DESCRIPTION
This is a very minor under-the-hood change.

Previously, all code-split chunks in an application used a numeric id + hash as their filename.  This is technically fine, but it becomes hard to tell which chunks are important when there are 100+ moment locale chunks each 5-20kb in size and just a few "core" chunks numbered something like `135`, `136`, and `137` which contain the actual application code.

This change adds a webpack magic comment which results in moment locale chunks generated into the `static/js/moment-locales` directory and named with the tag of the relevant locale instead of a random number (`fr.HASH.js` instead of `13.HASH.js`)