### PR TITLE
feat: add support for generating manifest app_hub_id from d2.config id [LIBS-132]

### DIFF
--- a/cli/src/lib/generateManifest.js
+++ b/cli/src/lib/generateManifest.js
@@ -3,6 +3,7 @@ const fs = require('fs-extra')
 
 module.exports = (paths, config, publicUrl) => {
     const manifest = {
+        app_hub_id: config.id,
         appType: 'APP',
         short_name: config.name,
         name: config.title,

--- a/examples/simple-app/d2.config.js
+++ b/examples/simple-app/d2.config.js
@@ -1,9 +1,10 @@
 const config = {
+    id: 'ASDF1234', // This must match the AppHub ID to successfully publish
     name: 'simple-app',
     title: 'Simple Example App',
     description: 'This is a simple example application',
 
-    standalone: true, // Don't bake-in a DHIS2 base URL, allow the user to choose
+    // standalone: true, // Don't bake-in a DHIS2 base URL, allow the user to choose
 
     entryPoints: {
         app: './src/App',


### PR DESCRIPTION
Generates `app_hub_id` in `webapp.manifest` (and `id` in `d2.config.json`) from `id` in `d2.config.js`