### PR TITLE
fix: allow for nested entry-points under src

### DIFF
--- a/cli/src/lib/validators/validatePackageExports.js
+++ b/cli/src/lib/validators/validatePackageExports.js
@@ -31,21 +31,20 @@ module.exports.validatePackageExports = async (
     const baseDir = path.dirname(paths.package)
 
     let valid = true
-    const entrypointBasename = normalizeExtension(
-        path.basename(config.entryPoints.lib)
-    )
+    const entrypointBasename = normalizeExtension(config.entryPoints.lib)
+    const relativeEntrypoint = path.relative('src', entrypointBasename)
 
     const expectedESMExport =
         './' +
         path.relative(
             baseDir,
-            path.join(paths.buildOutput, 'es', entrypointBasename)
+            path.join(paths.buildOutput, 'es', relativeEntrypoint)
         )
     const expectedCJSExport =
         './' +
         path.relative(
             baseDir,
-            path.join(paths.buildOutput, 'cjs', entrypointBasename)
+            path.join(paths.buildOutput, 'cjs', relativeEntrypoint)
         )
 
     const expectedPackage = {

--- a/cli/src/lib/validators/validatePackageExports.js
+++ b/cli/src/lib/validators/validatePackageExports.js
@@ -31,8 +31,10 @@ module.exports.validatePackageExports = async (
     const baseDir = path.dirname(paths.package)
 
     let valid = true
-    const entrypointBasename = normalizeExtension(config.entryPoints.lib)
-    const relativeEntrypoint = path.relative('src', entrypointBasename)
+    const relativeEntrypoint = path.relative(
+        paths.src,
+        normalizeExtension(config.entryPoints.lib)
+    )
 
     const expectedESMExport =
         './' +


### PR DESCRIPTION
This change makes it so that we resolve the entry-point relatively to
the src folder, so src/react/index.js becomes react/index.js.

This resolves an issue when the library entry-point is not defined as
src/index.js.

So for example src/react/index.js will fail to build because we only
used the basename (index.js) to construct the build entry-point path, so
the react part of the path disappears from the expected path.

We got build/es/index.js when we should have gotten
build/es/react/index.js.

Since we force users of app-scripts to put their source code under
'src' (compiler/compile.js:15), we can safely assume that the configured
entry-point can be resolved relatively to the src directory and grab
everything to the right and build the path to the target directory, e.g.
build/es/react/index.js.