### PR TITLE
fix: allow jest to ignore the build folder

### DIFF
--- a/cli/config/jest.config.js
+++ b/cli/config/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
     transform: {
         '^.+\\.[t|j]sx?$': require.resolve('./jest.transform.js'),
     },
+    modulePathIgnorePatterns: ['build'],
     moduleNameMapper: {
         '\\.(css|less)$': require.resolve('./jest.identity.mock.js'),
         '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': require.resolve(


### PR DESCRIPTION
Now that we only use Babel to transpile sources to CJS and ES, we also
copy over everything in the source directory to the build directly.

Using UI as an example, that includes for example:

- `**/features/*`
- `**/*.test.js`
- `**/*.stories.js`
- `**/*.stories.e2e.js`

The test files proved problematic because Jest picks them up from the
build folder as well as the source folder, causing the tests to be run
thrice: src, build/es, and build/cjs.

Furthermore, it is not necessary true that tests can be transpiled and
still work as expected. We saw this in UI as well, where the test in src
passes, but the test in build/cjs fails.

As a first step this fixes the test command so that Jest ignores tests
under the build folder.