### PR TITLE
fix: don't render application until we are sure the locale is initialized

### DIFF
--- a/adapter/src/components/AuthBoundary.js
+++ b/adapter/src/components/AuthBoundary.js
@@ -13,9 +13,11 @@ const settingsQuery = {
 
 export const AuthBoundary = ({ url, children }) => {
     const { loading, error, data } = useDataQuery(settingsQuery)
-    useLocale(data && data.userSettings.keyUiLocale)
+    const locale = useLocale(
+        data && (data.userSettings.keyUiLocale || window.navigator.language)
+    )
 
-    if (loading) {
+    if (loading || !locale) {
         return <LoadingMask />
     }
 

--- a/adapter/src/utils/useLocale.js
+++ b/adapter/src/utils/useLocale.js
@@ -1,6 +1,6 @@
 import i18n from '@dhis2/d2-i18n'
 import moment from 'moment'
-import { useEffect } from 'react'
+import { useState, useEffect } from 'react'
 
 i18n.setDefaultNamespace('default')
 
@@ -27,7 +27,13 @@ const setGlobalLocale = locale => {
 }
 
 export const useLocale = locale => {
+    const [result, setResult] = useState(undefined)
     useEffect(() => {
-        setGlobalLocale(locale || window.navigator.language)
+        if (!locale) {
+            return
+        }
+        setGlobalLocale(locale)
+        setResult(locale)
     }, [locale])
+    return result
 }


### PR DESCRIPTION
Because we set the locale state in a `useEffect`, there was a subtle race condition bug which could cause the application to render before the locale is set.  When this happens, strings in the app are not correctly translated because the locale hasn't yet been switch from English to whatever the user has selected.