### PR TITLE
fix: show login modal before locale is loaded

### DIFF
--- a/adapter/src/components/AuthBoundary.js
+++ b/adapter/src/components/AuthBoundary.js
@@ -17,12 +17,12 @@ export const AuthBoundary = ({ url, children }) => {
         data && (data.userSettings.keyUiLocale || window.navigator.language)
     )
 
-    if (loading || !locale) {
-        return <LoadingMask />
-    }
-
     if (error) {
         return <LoginModal url={url} />
+    }
+
+    if (loading || !locale) {
+        return <LoadingMask />
     }
 
     return children


### PR DESCRIPTION
The change to wait for locale initialization resulted in the LoginModal never rendering, this fixes that issue.

Thanks @mediremi for flagging this