### PR TITLE
feat(publish): upload apps to App Hub

### DIFF
--- a/cli/src/commands/publish.js
+++ b/cli/src/commands/publish.js
@@ -83,10 +83,7 @@ const resolveBundle = (cwd, params) => {
 }
 
 const promptForConfig = async params => {
-    const requiredParams = ['appId', 'apiKey', 'minVersion']
-    const isMissingParam = requiredParams.some(p => !params[p])
-
-    if (process.env.CI && isMissingParam) {
+    if (process.env.CI && (!params.apiKey || !params.minVersion)) {
         reporter.error(
             'Prompt disabled in CI mode - missing baseUrl, username, or password parameter.'
         )

--- a/cli/src/commands/publish.js
+++ b/cli/src/commands/publish.js
@@ -136,7 +136,7 @@ const promptForConfig = async params => {
             type: 'input',
             name: 'apikey',
             message: 'App Hub API-key',
-            when: () => !params.apikey && !process.env.D2_APP_HUB_API_KEY,
+            when: () => !apiKey,
         },
         {
             type: 'input',
@@ -170,6 +170,7 @@ const promptForConfig = async params => {
 
     return {
         ...params,
+        apikey: apiKey,
         ...responses,
     }
 }
@@ -180,12 +181,10 @@ const handler = async ({ cwd = process.cwd(), ...params }) => {
     const appBundle = resolveBundle(cwd, publishConfig)
     const uploadAppUrl = constructUploadUrl(appBundle.id)
 
-    const resolvedApiKey =
-        publishConfig.apikey || process.env.D2_APP_HUB_API_KEY
     const client = createClient({
         baseUrl: publishConfig.baseUrl,
         headers: {
-            'x-api-key': resolvedApiKey,
+            'x-api-key': publishConfig.apikey,
         },
     })
 
@@ -208,7 +207,7 @@ const handler = async ({ cwd = process.cwd(), ...params }) => {
 
         await client.post(uploadAppUrl, formData, {
             headers: formData.getHeaders(),
-            timeout: 30000, // Ensure we have enough time to upload a large zip file
+            timeout: 300000, // Ensure we have enough time to upload a large zip file
         })
         reporter.info(
             `Successfully published ${appBundle.name} with version ${appBundle.version}`

--- a/cli/src/commands/publish.js
+++ b/cli/src/commands/publish.js
@@ -85,7 +85,7 @@ const resolveBundle = (cwd, params) => {
 const promptForConfig = async params => {
     if (process.env.CI && (!params.apiKey || !params.minVersion)) {
         reporter.error(
-            'Prompt disabled in CI mode - missing baseUrl, username, or password parameter.'
+            'Prompt disabled in CI mode - missing apiKey or minVersion parameter.'
         )
         process.exit(1)
     }

--- a/cli/src/commands/publish.js
+++ b/cli/src/commands/publish.js
@@ -130,7 +130,7 @@ const promptForConfig = async params => {
             type: 'input',
             name: 'apikey',
             message: 'App Hub API-key',
-            when: () => !params.apikey,
+            when: () => !params.apikey && !process.env.D2_APP_HUB_API_KEY,
         },
         {
             type: 'input',
@@ -174,10 +174,12 @@ const handler = async ({ cwd = process.cwd(), ...params }) => {
     const appBundle = resolveBundle(cwd, publishConfig)
     const uploadAppUrl = constructUploadUrl(appBundle.id)
 
+    const resolvedApiKey =
+        publishConfig.apikey || process.env.D2_APP_HUB_API_KEY
     const client = createClient({
         baseUrl: publishConfig.baseUrl,
         headers: {
-            'x-api-key': publishConfig.apikey,
+            'x-api-key': resolvedApiKey,
         },
     })
 

--- a/cli/src/commands/publish.js
+++ b/cli/src/commands/publish.js
@@ -130,6 +130,7 @@ const handler = async ({ cwd = process.cwd(), ...params }) => {
             'x-api-key': publishConfig.apiKey,
         },
     })
+
     const versionData = {
         version: appBundle.version,
         minDhisVersion: publishConfig.minVersion,
@@ -147,7 +148,6 @@ const handler = async ({ cwd = process.cwd(), ...params }) => {
 
         await client.post(uploadAppUrl, formData, {
             headers: formData.getHeaders(),
-            port: 3000,
             timeout: 30000, // Ensure we have enough time to upload a large zip file
         })
         reporter.info(

--- a/cli/src/commands/publish.js
+++ b/cli/src/commands/publish.js
@@ -37,13 +37,12 @@ const resolveBundle = (cwd, params) => {
                 reporter.error(`${params.file} is not a file`)
                 process.exit(1)
             }
-            appBundle.path = filePath
-            appBundle.version = params.fileVersion
-            appBundle.name = path.basename(filePath)
             appBundle.id = params.appId
+            appBundle.version = params.fileVersion
+            appBundle.path = filePath
+            appBundle.name = path.basename(filePath)
         } catch (e) {
-            console.error(e)
-            reporter.error(`File not found at ${params.file}`)
+            reporter.error(`File does not exist at ${params.file}`)
             process.exit(1)
         }
     } else {
@@ -60,7 +59,6 @@ const resolveBundle = (cwd, params) => {
         }
         appBundle.id = builtAppConfig.id
         appBundle.version = builtAppConfig.version
-
         appBundle.path = path.relative(
             cwd,
             paths.buildAppBundle

--- a/cli/src/commands/publish.js
+++ b/cli/src/commands/publish.js
@@ -1,0 +1,221 @@
+const path = require('path')
+const { reporter, chalk } = require('@dhis2/cli-helpers-engine')
+const FormData = require('form-data')
+const fs = require('fs-extra')
+const inquirer = require('inquirer')
+const { createClient } = require('../lib/httpClient')
+const parseConfig = require('../lib/parseConfig')
+const makePaths = require('../lib/paths')
+
+const constructUploadUrl = appId => `/api/v1/apps/${appId}/versions`
+
+const isValidServerVersion = v => !!/(\d+)\.(\d+)/.exec(v)
+
+const dumpHttpError = (message, response) => {
+    if (!response) {
+        reporter.error(message)
+        return
+    }
+
+    reporter.error(
+        message,
+        response.status,
+        typeof response.data === 'object'
+            ? response.data.message
+            : response.statusText
+    )
+    reporter.debugErr('Error details', response.data)
+}
+
+const resolveBundle = (cwd, params) => {
+    const appBundle = {}
+    // use file-path from params
+    if (params.file) {
+        try {
+            const filePath = path.resolve(cwd, params.file)
+            if (!fs.statSync(filePath).isFile()) {
+                reporter.error(`${params.file} is not a file`)
+                process.exit(1)
+            }
+            appBundle.path = filePath
+            appBundle.version = params.fileVersion
+            appBundle.name = path.basename(filePath)
+            appBundle.id = params.appId
+        } catch (e) {
+            console.error(e)
+            reporter.error(`File not found at ${params.file}`)
+            process.exit(1)
+        }
+    } else {
+        // resolve file from built-bundle
+        const paths = makePaths(cwd)
+        const builtAppConfig = parseConfig(paths)
+        if (!builtAppConfig.id) {
+            reporter.error(
+                `No App Hub id found for app. Add an ${chalk.bold(
+                    'id'
+                )}-field to ${chalk.bold('d2.config.js')}`
+            )
+            process.exit(1)
+        }
+        appBundle.id = builtAppConfig.id
+        appBundle.version = builtAppConfig.version
+
+        appBundle.path = path.relative(
+            cwd,
+            paths.buildAppBundle
+                .replace(/{{name}}/, builtAppConfig.name)
+                .replace(/{{version}}/, builtAppConfig.version)
+        )
+        appBundle.name = builtAppConfig.name
+
+        if (!fs.existsSync(appBundle.path)) {
+            reporter.error(
+                `App bundle does not exist, run ${chalk.bold(
+                    'd2-app-scripts build'
+                )} before deploying.`
+            )
+            process.exit(1)
+        }
+    }
+
+    return appBundle
+}
+
+const promptForConfig = async params => {
+    const requiredParams = ['appId', 'apiKey', 'minVersion']
+    const isMissingParam = requiredParams.some(p => !params[p])
+
+    if (process.env.CI && isMissingParam) {
+        reporter.error(
+            'Prompt disabled in CI mode - missing baseUrl, username, or password parameter.'
+        )
+        process.exit(1)
+    }
+
+    const responses = await inquirer.prompt([
+        {
+            type: 'input',
+            name: 'apiKey',
+            message: 'App Hub API-key',
+            when: () => !params.apiKey,
+        },
+        {
+            type: 'input',
+            name: 'minVersion',
+            message: 'Minimum DHIS2 version supported',
+            when: () => !params.minVersion,
+            validate: v =>
+                isValidServerVersion(v) ? true : 'Invalid server version',
+        },
+        {
+            type: 'input',
+            name: 'maxVersion',
+            message: 'Maximum DHIS2 version supported',
+            when: () => !params.maxVersion,
+            validate: v =>
+                !v || isValidServerVersion(v) ? true : 'Invalid server version',
+        },
+    ])
+
+    return {
+        ...params,
+        ...responses,
+    }
+}
+
+const handler = async ({ cwd = process.cwd(), ...params }) => {
+    const appBundle = resolveBundle(cwd, params)
+    const uploadAppUrl = constructUploadUrl(appBundle.id)
+    const publishConfig = await promptForConfig(params)
+
+    const client = createClient({
+        baseUrl: params.baseUrl,
+        headers: {
+            'x-api-key': publishConfig.apiKey,
+        },
+    })
+    const versionData = {
+        version: appBundle.version,
+        minDhisVersion: publishConfig.minVersion,
+        maxDhisVersion: publishConfig.maxVersion,
+        channel: publishConfig.channel,
+    }
+
+    const formData = new FormData()
+    formData.append('file', fs.createReadStream(appBundle.path))
+    formData.append('version', JSON.stringify(versionData))
+
+    try {
+        reporter.print(`Uploading app bundle to ${uploadAppUrl}`)
+        reporter.debug('Upload with version data', versionData)
+
+        await client.post(uploadAppUrl, formData, {
+            headers: formData.getHeaders(),
+            port: 3000,
+            timeout: 30000, // Ensure we have enough time to upload a large zip file
+        })
+        reporter.info(
+            `Successfully published ${appBundle.name} with version ${appBundle.version}`
+        )
+    } catch (e) {
+        if (e.isAxiosError) {
+            dumpHttpError('Failed to upload app, HTTP error', e.response)
+        } else {
+            reporter.error(e)
+        }
+        process.exit(1)
+    }
+}
+
+const command = {
+    command: 'publish',
+    alias: 'p',
+    desc: 'Deploy the built application to a specific DHIS2 instance',
+    builder: yargs =>
+        yargs.options({
+            apiKey: {
+                alias: 'k',
+                type: 'string',
+                description: 'The API-key to use for authentication',
+            },
+            channel: {
+                alias: 'c',
+                description: 'The channel to publish the app-version to',
+                default: 'stable',
+            },
+            baseUrl: {
+                alias: 'b',
+                description: 'The base-url of the App Hub instance',
+                default: 'https://apps.dhis2.org',
+            },
+            minVersion: {
+                type: 'string',
+                description: 'The minimum version of DHIS2 the app supports',
+            },
+            maxVersion: {
+                type: 'string',
+                description: 'The maximum version of DHIS2 the app supports',
+            },
+            appId: {
+                type: 'string',
+                description:
+                    'Only used with --file option. The App Hub ID for the App to publish to',
+                implies: 'file',
+            },
+            file: {
+                description:
+                    'Path to the file to upload. This skips automatic resolution of the built app and uses this file-path to upload',
+                implies: ['file-version', 'appId'],
+            },
+            'file-version': {
+                type: 'string',
+                description:
+                    'Only used with --file option. The semantic version of the app uploaded',
+                implies: 'file',
+            },
+        }),
+    handler,
+}
+
+module.exports = command

--- a/cli/src/commands/publish.js
+++ b/cli/src/commands/publish.js
@@ -81,9 +81,9 @@ const resolveBundle = (cwd, params) => {
 }
 
 const promptForConfig = async params => {
-    if (process.env.CI && (!params.apiKey || !params.minVersion)) {
+    if (process.env.CI && (!params.apikey || !params.minVersion)) {
         reporter.error(
-            'Prompt disabled in CI mode - missing apiKey or minVersion parameter.'
+            'Prompt disabled in CI mode - missing apikey or minVersion parameter.'
         )
         process.exit(1)
     }
@@ -91,9 +91,9 @@ const promptForConfig = async params => {
     const responses = await inquirer.prompt([
         {
             type: 'input',
-            name: 'apiKey',
+            name: 'apikey',
             message: 'App Hub API-key',
-            when: () => !params.apiKey,
+            when: () => !params.apikey,
         },
         {
             type: 'input',
@@ -127,7 +127,7 @@ const handler = async ({ cwd = process.cwd(), ...params }) => {
     const client = createClient({
         baseUrl: params.baseUrl,
         headers: {
-            'x-api-key': publishConfig.apiKey,
+            'x-api-key': publishConfig.apikey,
         },
     })
 
@@ -169,7 +169,7 @@ const command = {
     desc: 'Deploy the built application to a specific DHIS2 instance',
     builder: yargs =>
         yargs.options({
-            apiKey: {
+            apikey: {
                 alias: 'k',
                 type: 'string',
                 description: 'The API-key to use for authentication',

--- a/docs/scripts/publish.md
+++ b/docs/scripts/publish.md
@@ -8,7 +8,7 @@ Note that you need an App Hub API key before using this command. The API key is 
 
 This command can only upload _versions_ to an app that **already** exists on the App Hub. The app must have an `id`-field in the `d2.config.js` which matches the id of the app on App Hub.
 
-This command will prompt the user for information not found in `d2.config.js` or in the parameters. The API key can be specified with the `D2_APIKEY` environment variable. For example, the following will publish the app without waiting for user input, given that `id` is in the config-file.
+This command will prompt the user for information not found in `d2.config.js` or in the parameters. The API key can be specified with the `D2_APP_HUB_API_KEY` environment variable. For example, the following will publish the app without waiting for user input, given that `id` is in the config-file.
 
 ```sh
 > d2 app scripts publish

--- a/docs/scripts/publish.md
+++ b/docs/scripts/publish.md
@@ -1,0 +1,44 @@
+# d2 app scripts publish
+
+Publishes a built application bundle to the [App Hub](https://apps.dhis2.org/).
+
+You must run `d2 app scripts build` **before** running `publish`
+
+Note that you need an App Hub API key before using this command. The API key is used to identify the user uploading the app. You can generate an API key after logging into the [App Hub](https://apps.dhis2.org/).
+
+This command can only upload _versions_ to an app that **already** exists on the App Hub. The app must have an `id`-field in the `d2.config.js` which matches the id of the app on App Hub.
+
+This command will prompt the user for information not found in `d2.config.js` or in the parameters. The API key can be specified with the `D2_APIKEY` environment variable. For example, the following will publish the app without waiting for user input, given that `id` is in the config-file.
+
+```sh
+> d2 app scripts publish
+> export D2_APIKEY=xyz
+> d2 app scripts publish --minVersion 2.34 --maxVersion 2.36
+```
+
+## Usage
+
+```sh
+> d2 app scripts publish --help
+d2-app-scripts publish
+
+Deploy the built application to a specific DHIS2 instance
+
+Options:
+  --cwd           working directory to use (defaults to cwd)
+  --version       Show version number                                  [boolean]
+  --config        Path to JSON config file
+  --apiKey, -k    The API-key to use for authentication                 [string]
+  --channel, -c   The channel to publish the app-version to  [default: "stable"]
+  --baseUrl, -b   The base-url of the App Hub instance
+                                             [default: "https://apps.dhis2.org"]
+  --minVersion    The minimum version of DHIS2 the app supports         [string]
+  --maxVersion    The maximum version of DHIS2 the app supports         [string]
+  --appId         Only used with --file option. The App Hub ID for the App to
+                  publish to                                            [string]
+  --file          Path to the file to upload. This skips automatic resolution of
+                  the built app and uses this file-path to upload
+  --file-version  Only used with --file option. The semantic version of the app
+                  uploaded                                              [string]
+  -h, --help      Show help                                            [boolean]
+```

--- a/docs/scripts/publish.md
+++ b/docs/scripts/publish.md
@@ -28,7 +28,7 @@ Options:
   --cwd           working directory to use (defaults to cwd)
   --version       Show version number                                  [boolean]
   --config        Path to JSON config file
-  --apiKey, -k    The API-key to use for authentication                 [string]
+  --apikey, -k    The API-key to use for authentication                 [string]
   --channel, -c   The channel to publish the app-version to  [default: "stable"]
   --baseUrl, -b   The base-url of the App Hub instance
                                              [default: "https://apps.dhis2.org"]


### PR DESCRIPTION
This adds a command that is pretty similar to `deploy`. It extracts some information from the built `appBundle`, however this uploads that bundle to App Hub instead of a DHIS2-instance. There's some code that is duplicated from `publish` (eg. `dumpHttpError`), could probably extract some of this to a common file. I didn't want to change more code than necessary.

This should mainly be used with app-platform apps, and it's thus very simple to use with a bundled app. However I added an escape hatch so that apps that are not migrated to the platform may use this to upload any arbitrary bundle to the app hub. That's why we have options like `appId`, `file` and `file-version`. There are not intended to be use for overriding the config from a built app, as we do not want discrepancies from the uploaded app-information and the app-manifest. 


### How to test it?
 API key generation is live on both staging and live server.

- Log in to https://staging.apps.dhis2.org/ 
- Navigate Api Key, and generate a new key
- Use API-key with `--apiKey` or set as env with `D2_apiKey=apiKey` when using the CLI.

TODO:

- [x] Initial implementation
- [x]  Initial docs
