### PR TITLE
feat: declarative i18n

### DIFF
--- a/cli/src/lib/i18n/collect.js
+++ b/cli/src/lib/i18n/collect.js
@@ -1,0 +1,59 @@
+const path = require('path')
+const fs = require('fs-extra')
+
+const localeFileSuffix = '.locale.js'
+const requiredDefaultLocale = 'en' // TODO: support entirely non-english libraries?
+const packageExportsNamespace = 'd2-i18n' // Suitably non-generic?
+
+const makeImport = (depName, locale) => {
+    // platform-built libraries should bundle their transitive deps at build/i18n
+    // exports: { "./d2-i18n/*": "./build/i18n/*" }
+    // Should be declared in `package.json`
+    return `${depName}/${packageExportsNamespace}/${locale}${localeFileSuffix}`
+}
+
+const collectLocalesFromDependency = (depName, defaultLocalePath) => {
+    const baseDir = path.dirname(defaultLocalePath)
+    const files = fs.readdirSync(baseDir)
+
+    return files
+        .filter(file => file.endsWith(localeFileSuffix))
+        .reduce((locales, file) => {
+            const locale = file.replace(new RegExp(`/${localeFileSuffix}$/`, ''))
+            locales[locale] = makeImport(depName, locale)
+            return locales
+        }, {})
+}
+
+export const collect = ({ paths }) => {
+    const pkg = require(paths.package)
+
+    const dependencies = pkg.dependencies
+
+    const importsByLocale = {}
+    
+    Object.keys(dependencies).forEach(dep => {
+        try {
+            const localeSourcePath = require.resolve(makeImport(dep, requiredDefaultLocale))
+            if (localeSourcePath) {
+                const locales = collectLocalesFromDependency(dep, localeSourcePath)
+                Object.keys(locales).forEach(locale => {
+                    importsByLocale[locale] = [...importsByLocale[locale], locales[locale]]
+                })
+            }
+            // TODO: deep find all deps in the tree?  (search transitive deps)
+        } catch (err) {
+            // ignore
+        }
+    })
+
+    /* 
+     * Sample output:
+     *   {
+     *     "en": ["dep1/d2-i18n/en.json", "dep2/d2-i18n/en.json", "dep3/d2-i18n/en.json"]
+     *     "fr"" ["dep1/d2-i18n/fr.json", "dep3/d2-i18n/fr.json"]
+     *     "nb": ["dep2/d2-i18n/nb.json", "dep3/d2-i18n/nb.json"]
+     *   }
+     */
+    return importsByLocale
+}

--- a/cli/src/lib/i18n/collect.js
+++ b/cli/src/lib/i18n/collect.js
@@ -19,7 +19,9 @@ const collectLocalesFromDependency = (depName, defaultLocalePath) => {
     return files
         .filter(file => file.endsWith(localeFileSuffix))
         .reduce((locales, file) => {
-            const locale = file.replace(new RegExp(`/${localeFileSuffix}$/`, ''))
+            const locale = file.replace(
+                new RegExp(`/${localeFileSuffix}$/`, '')
+            )
             locales[locale] = makeImport(depName, locale)
             return locales
         }, {})
@@ -31,14 +33,22 @@ export const collect = ({ paths }) => {
     const dependencies = pkg.dependencies
 
     const importsByLocale = {}
-    
+
     Object.keys(dependencies).forEach(dep => {
         try {
-            const localeSourcePath = require.resolve(makeImport(dep, requiredDefaultLocale))
+            const localeSourcePath = require.resolve(
+                makeImport(dep, requiredDefaultLocale)
+            )
             if (localeSourcePath) {
-                const locales = collectLocalesFromDependency(dep, localeSourcePath)
+                const locales = collectLocalesFromDependency(
+                    dep,
+                    localeSourcePath
+                )
                 Object.keys(locales).forEach(locale => {
-                    importsByLocale[locale] = [...importsByLocale[locale], locales[locale]]
+                    importsByLocale[locale] = [
+                        ...importsByLocale[locale],
+                        locales[locale],
+                    ]
                 })
             }
             // TODO: deep find all deps in the tree?  (search transitive deps)
@@ -47,7 +57,7 @@ export const collect = ({ paths }) => {
         }
     })
 
-    /* 
+    /*
      * Sample output:
      *   {
      *     "en": ["dep1/d2-i18n/en.json", "dep2/d2-i18n/en.json", "dep3/d2-i18n/en.json"]

--- a/cli/src/lib/i18n/index.js
+++ b/cli/src/lib/i18n/index.js
@@ -1,9 +1,11 @@
 const extract = require('./extract')
 const generate = require('./generate')
 const validate = require('./validate')
+const collect = require('./collect.js')
 
 module.exports = {
     extract,
     generate,
     validate,
+    collect,
 }

--- a/cli/src/lib/i18n/index.js
+++ b/cli/src/lib/i18n/index.js
@@ -1,7 +1,7 @@
+const collect = require('./collect.js')
 const extract = require('./extract')
 const generate = require('./generate')
 const validate = require('./validate')
-const collect = require('./collect.js')
 
 module.exports = {
     extract,


### PR DESCRIPTION
**WORK IN PROGRESS**

This change will:
- [ ] support building i18n locales as separate exports of platform-built library (i.e. `@dhis2/ui-widgets/d2-i18n/fr.locale.json`) with appropriate `exports` declaration in `package.json`
- [x] implement logic for collecting locale strings from dependencies
- [ ] generate i18n js modules into shell, rather than into app source
- [ ] Add initialization and loading logic to `app-adapter`, including bundle-split locale modules and dynamically loaded (`import()`) strings per language (rather than including all strings in the main app bundle), including also the `moment` locale for a given locale
- [ ] Use package validation and a codemod to remove generated sources from /src in apps and libs, update all `./locales/index.js` and `@dhis2/d2-i18n` imports in the codebase, and correct package.json, .gitignore, and other config files as much as possible
