### PR TITLE
fix: respect --cwd argument when generating/extracting translations

### DIFF
--- a/cli/src/commands/build.js
+++ b/cli/src/commands/build.js
@@ -89,11 +89,16 @@ const handler = async ({
             }
 
             reporter.info('Generating internationalization strings...')
-            await i18n.extract({ input: paths.src, output: paths.i18nStrings })
+            await i18n.extract({
+                input: paths.src,
+                output: paths.i18nStrings,
+                paths,
+            })
             await i18n.generate({
                 input: paths.i18nStrings,
                 output: paths.i18nLocales,
                 namespace: 'default',
+                paths,
             })
 
             if (config.type === 'app') {

--- a/cli/src/commands/i18n.js
+++ b/cli/src/commands/i18n.js
@@ -1,32 +1,25 @@
 const { namespace, reporter } = require('@dhis2/cli-helpers-engine')
 const i18n = require('../lib/i18n')
+const makePaths = require('../lib/paths')
 
 const generate = {
     description:
         'Generate JSON files compatible with i18next from po/pot files',
     builder: {
-        path: {
-            alias: 'p',
-            description:
-                'directory path to find .po/.pot files and convert to JSON',
-            default: './i18n/',
-        },
-        output: {
-            alias: 'o',
-            description: 'Output directory to place converted JSON files.',
-            default: './src/locales/',
-        },
         namespace: {
             alias: 'n',
             description: 'Namespace for app locale separation',
             default: 'default',
         },
     },
-    handler: async argv => {
+    handler: async ({ cwd, namespace }) => {
+        const paths = makePaths(cwd)
+
         const result = await i18n.generate({
-            input: argv.path,
-            output: argv.output,
-            namespace: argv.namespace,
+            input: paths.i18nStrings,
+            output: paths.i18nLocales,
+            namespace,
+            paths,
         })
 
         if (!result) {
@@ -38,23 +31,13 @@ const generate = {
 }
 const extract = {
     description: 'Extract strings-to-translate',
-    builder: {
-        path: {
-            alias: 'p',
-            description:
-                'Directory path to recurse and extract i18n.t translation strings',
-            default: './src/',
-        },
-        output: {
-            alias: 'o',
-            description: 'Destination path for en.pot file',
-            default: './i18n/',
-        },
-    },
-    handler: async argv => {
+    handler: async ({ cwd }) => {
+        const paths = makePaths(cwd)
+
         const result = await i18n.extract({
-            input: argv.path,
-            output: argv.output,
+            input: paths.src,
+            output: paths.i18nStrings,
+            paths,
         })
         if (!result) {
             reporter.error('Failed to extract i18n strings.')

--- a/cli/src/commands/i18n.js
+++ b/cli/src/commands/i18n.js
@@ -6,18 +6,27 @@ const generate = {
     description:
         'Generate JSON files compatible with i18next from po/pot files',
     builder: {
+        path: {
+            alias: 'p',
+            description:
+                'directory path to find .po/.pot files and convert to JSON',
+        },
+        output: {
+            alias: 'o',
+            description: 'Output directory to place converted JSON files.',
+        },
         namespace: {
             alias: 'n',
             description: 'Namespace for app locale separation',
             default: 'default',
         },
     },
-    handler: async ({ cwd, namespace }) => {
+    handler: async ({ cwd, path, output, namespace }) => {
         const paths = makePaths(cwd)
 
         const result = await i18n.generate({
-            input: paths.i18nStrings,
-            output: paths.i18nLocales,
+            input: path || paths.i18nStrings,
+            output: output || paths.i18nLocales,
             namespace,
             paths,
         })
@@ -31,12 +40,23 @@ const generate = {
 }
 const extract = {
     description: 'Extract strings-to-translate',
-    handler: async ({ cwd }) => {
+    builder: {
+        path: {
+            alias: 'p',
+            description:
+                'Directory path to recurse and extract i18n.t translation strings',
+        },
+        output: {
+            alias: 'o',
+            description: 'Destination path for en.pot file',
+        },
+    },
+    handler: async ({ cwd, path, output }) => {
         const paths = makePaths(cwd)
 
         const result = await i18n.extract({
-            input: paths.src,
-            output: paths.i18nStrings,
+            input: path || paths.src,
+            output: output || paths.i18nStrings,
             paths,
         })
         if (!result) {

--- a/cli/src/commands/start.js
+++ b/cli/src/commands/start.js
@@ -48,11 +48,16 @@ const handler = async ({
             }
 
             reporter.info('Generating internationalization strings...')
-            await i18n.extract({ input: paths.src, output: paths.i18nStrings })
+            await i18n.extract({
+                input: paths.src,
+                output: paths.i18nStrings,
+                paths,
+            })
             await i18n.generate({
                 input: paths.i18nStrings,
                 output: paths.i18nLocales,
                 namespace: 'default',
+                paths,
             })
 
             reporter.info('Bootstrapping local appShell...')

--- a/cli/src/lib/i18n/extract.js
+++ b/cli/src/lib/i18n/extract.js
@@ -5,8 +5,8 @@ const { i18nextToPot, gettextToI18next } = require('i18next-conv')
 const scanner = require('i18next-scanner')
 const { checkDirectoryExists, walkDirectory, arrayEqual } = require('./helpers')
 
-const extract = async ({ input, output }) => {
-    const relativeInput = './' + path.relative(process.cwd(), input)
+const extract = async ({ input, output, paths }) => {
+    const relativeInput = './' + path.relative(paths.base, input)
     if (!checkDirectoryExists(input)) {
         reporter.error(
             `I18n source directory ${chalk.bold(relativeInput)} does not exist.`
@@ -73,7 +73,7 @@ const extract = async ({ input, output }) => {
     reporter.print(
         chalk.dim(
             `Writing ${Object.keys(en).length} language strings to ${chalk.bold(
-                './' + path.relative(process.cwd(), targetPath)
+                './' + path.relative(paths.base, targetPath)
             )}...`
         )
     )

--- a/cli/src/lib/i18n/extract.js
+++ b/cli/src/lib/i18n/extract.js
@@ -73,7 +73,7 @@ const extract = async ({ input, output }) => {
     reporter.print(
         chalk.dim(
             `Writing ${Object.keys(en).length} language strings to ${chalk.bold(
-                './' + targetPath
+                './' + path.relative(process.cwd(), targetPath)
             )}...`
         )
     )

--- a/cli/src/lib/i18n/generate.js
+++ b/cli/src/lib/i18n/generate.js
@@ -15,9 +15,9 @@ const writeTemplate = (outFile, data) => {
     fs.writeFileSync(outFile, localesTemplate(data))
 }
 
-const generate = async ({ input, output, namespace }) => {
+const generate = async ({ input, output, namespace, paths }) => {
     if (!checkDirectoryExists(input)) {
-        const relativeInput = './' + path.relative(process.cwd(), input)
+        const relativeInput = './' + path.relative(paths.base, input)
         reporter.debug(
             `Source directory ${chalk.bold(
                 relativeInput


### PR DESCRIPTION
Currently, when generating `i18n` strings (either as a result of `d2-app-scripts start` or `d2-app-scripts extract`), a message in the format below is logged:

```
Writing N language strings to .//home/user/some/path/app-being-developed/i18n/en.pot...
```

This PR ensures that the path to `en.pot` logged is relative to the current working directory, resulting in the more consice:

```
Writing N language strings to ./en.pot...
```