### PR TITLE
fix: set default value for all strings

### DIFF
--- a/cli/src/lib/i18n/extract.js
+++ b/cli/src/lib/i18n/extract.js
@@ -30,7 +30,7 @@ const extract = async ({ input, output, paths }) => {
         keySeparator: false,
         sort: true,
         defaultValue: (lng, ns, key, options) =>
-            options.defaultValue ? options.defaultValue : key
+            options.defaultValue ? options.defaultValue : key,
     })
     /* eslint-enable max-params */
 

--- a/cli/src/lib/i18n/extract.js
+++ b/cli/src/lib/i18n/extract.js
@@ -28,6 +28,8 @@ const extract = async ({ input, output, paths }) => {
         keepRemoved: false,
         keySeparator: false,
         sort: true,
+        defaultValue: (lng, ns, key, options) =>
+            options.defaultValue ? options.defaultValue : key
     })
 
     reporter.debug(`[i18n-extract] Parsing ${files.length} files...`)

--- a/cli/src/lib/i18n/extract.js
+++ b/cli/src/lib/i18n/extract.js
@@ -24,6 +24,7 @@ const extract = async ({ input, output, paths }) => {
         process.exit(1)
     }
 
+    /* eslint-disable max-params */
     var parser = new scanner.Parser({
         keepRemoved: false,
         keySeparator: false,
@@ -31,6 +32,7 @@ const extract = async ({ input, output, paths }) => {
         defaultValue: (lng, ns, key, options) =>
             options.defaultValue ? options.defaultValue : key
     })
+    /* eslint-enable max-params */
 
     reporter.debug(`[i18n-extract] Parsing ${files.length} files...`)
 


### PR DESCRIPTION
A default value will be set for every string. if no default value is specifically provided, then the key will be used.  The end result is that the generated `en.pot` file contains translations for every string. This pot file is then accepted by transifex, allowing plurals to be properly translated. (after much trial and error together with Phil, we found that Transifex will not parse the imported pot file if only some of the strings have values)

d2-ui/interpretations currently uses this modified version of the extract.js script and it works as expected: https://github.com/dhis2/d2-ui/blob/master/packages/interpretations/scripts/extract.js

Would it be possible to release a beta to be tested with the DV app?

Here is an example of how plurals would look in code:
```
const replies = i18n.t(
            '{{count}} replies',
            {
                count: repliedBy.length,
                defaultValue: '{{count}} reply',
                defaultValue_plural: '{{count}} replies'
            });
```
(https://github.com/dhis2/d2-ui/blob/master/packages/interpretations/src/components/Interpretation/Replies.js#L73)