### PR TITLE
fix: add file extension to default entrypoints in d2.config

### DIFF
--- a/cli/config/d2.config.app.js
+++ b/cli/config/d2.config.app.js
@@ -2,7 +2,7 @@ const config = {
     type: 'app',
 
     entryPoints: {
-        app: './src/App',
+        app: './src/App.js',
     },
 }
 

--- a/cli/config/d2.config.lib.js
+++ b/cli/config/d2.config.lib.js
@@ -2,7 +2,7 @@ const config = {
     type: 'lib',
 
     entryPoints: {
-        lib: './src/index',
+        lib: './src/index.js',
     },
 }
 


### PR DESCRIPTION
This fixes an issue when using cjs `require`s from a d2 lib package. Also added to the default app `d2.config` for consistency