### PR TITLE
fix: rename 'update' test command handler parameter to 'updateSnapshot'

### DIFF
--- a/cli/src/commands/test.js
+++ b/cli/src/commands/test.js
@@ -9,7 +9,7 @@ const handler = async ({
     verbose,
     cwd,
     testRegex,
-    update,
+    updateSnapshot,
     coverage,
     watch,
     watchAll,
@@ -44,7 +44,7 @@ const handler = async ({
                 {
                     testPathPattern: testRegex,
                     config: JSON.stringify(jestConfig),
-                    updateSnapshot: !ci && update,
+                    updateSnapshot: !ci && updateSnapshot,
                     collectCoverage: coverage,
                     watch: (!ci && watch) || undefined,
                     watchAll: (!ci && watchAll) || undefined,


### PR DESCRIPTION
The [`updateSnapshot` parameter for the `test` command](https://github.com/dhis2/app-platform/blob/4e704c74bc5f02774f360fe65d8a684749affc02/cli/src/commands/test.js#L77-L82) was incorrectly referred to as `update` in its handler, hence it was impossible to set it to `true`.