### PR TITLE
feat(adapter): smarter error boundaries

### DIFF
--- a/adapter/src/components/ErrorBoundary.js
+++ b/adapter/src/components/ErrorBoundary.js
@@ -1,7 +1,8 @@
 import i18n from '@dhis2/d2-i18n'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import styles from './styles/FatalErrorBoundary.style'
+import styles from './styles/ErrorBoundary.style'
 
 const translatedErrorHeading = i18n.t(
     'An error occurred in the DHIS2 application.'
@@ -12,7 +13,7 @@ const replaceNewlinesWithBreaks = text =>
         .split('\n')
         .reduce((out, line, i) => [...out, line, <br key={i} />], [])
 
-export class FatalErrorBoundary extends Component {
+export class ErrorBoundary extends Component {
     constructor(props) {
         super(props)
         this.state = {
@@ -39,7 +40,11 @@ export class FatalErrorBoundary extends Component {
         const { children } = this.props
         if (this.state.error) {
             return (
-                <div className="mask">
+                <div
+                    className={cx('mask', {
+                        fullscreen: this.props.fullscreen,
+                    })}
+                >
                     <style jsx>{styles}</style>
                     <div className="container">
                         {/* <InfoIcon className="icon" /> */}
@@ -48,7 +53,9 @@ export class FatalErrorBoundary extends Component {
                         </div>
                         <div
                             className="link"
-                            onClick={() => window.location.reload()}
+                            onClick={() => {
+                                this.props.onRefresh && this.props.onRefresh()
+                            }}
                         >
                             {i18n.t('Refresh to try again')}
                         </div>
@@ -93,6 +100,8 @@ export class FatalErrorBoundary extends Component {
     }
 }
 
-FatalErrorBoundary.propTypes = {
+ErrorBoundary.propTypes = {
     children: PropTypes.node.isRequired,
+    fullscreen: PropTypes.bool,
+    onRefresh: PropTypes.func,
 }

--- a/adapter/src/components/styles/ErrorBoundary.style.js
+++ b/adapter/src/components/styles/ErrorBoundary.style.js
@@ -8,11 +8,8 @@ const bgColor = '#F4F6F8',
 
 export default css`
     .mask {
-        position: absolute;
-        top: 0px;
-        left: 0px;
-        right: 0px;
-        bottom: 0px;
+        height: 100%;
+        width: 100%;
 
         overflow: auto;
         overflow-y: auto;
@@ -27,6 +24,14 @@ export default css`
 
         align-items: center;
         justify-content: center;
+    }
+
+    .fullscreen {
+        position: absolute;
+        top: 0px;
+        left: 0px;
+        right: 0px;
+        bottom: 0px;
     }
 
     .container {

--- a/adapter/src/index.js
+++ b/adapter/src/index.js
@@ -5,14 +5,14 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { Alerts } from './components/Alerts'
 import { AuthBoundary } from './components/AuthBoundary'
-import { FatalErrorBoundary } from './components/FatalErrorBoundary'
+import { ErrorBoundary } from './components/ErrorBoundary'
 import { ServerVersionProvider } from './components/ServerVersionProvider'
 import { styles } from './styles.js'
 
 const offlineInterface = new OfflineInterface()
 
 const App = ({ url, apiVersion, appName, pwaEnabled, children }) => (
-    <FatalErrorBoundary>
+    <ErrorBoundary fullscreen onRefresh={() => window.location.reload()}>
         <ServerVersionProvider url={url} apiVersion={apiVersion}>
             <OfflineProvider
                 offlineInterface={offlineInterface}
@@ -22,13 +22,19 @@ const App = ({ url, apiVersion, appName, pwaEnabled, children }) => (
                     <style jsx>{styles}</style>
                     <HeaderBar appName={appName} />
                     <AuthBoundary url={url}>
-                        <div className="app-shell-app">{children}</div>
+                        <div className="app-shell-app">
+                            <ErrorBoundary
+                                onRefresh={() => window.location.reload()}
+                            >
+                                {children}
+                            </ErrorBoundary>
+                        </div>
                     </AuthBoundary>
                     <Alerts />
                 </div>
             </OfflineProvider>
         </ServerVersionProvider>
-    </FatalErrorBoundary>
+    </ErrorBoundary>
 )
 
 App.propTypes = {

--- a/adapter/src/index.js
+++ b/adapter/src/index.js
@@ -1,5 +1,5 @@
 import { OfflineProvider } from '@dhis2/app-service-offline'
-import { OfflineInterface } from '@dhis2/sw'
+import { checkForSWUpdateAndReload, OfflineInterface } from '@dhis2/sw'
 import { HeaderBar } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -12,7 +12,7 @@ import { styles } from './styles.js'
 const offlineInterface = new OfflineInterface()
 
 const App = ({ url, apiVersion, appName, pwaEnabled, children }) => (
-    <ErrorBoundary fullscreen onRefresh={() => window.location.reload()}>
+    <ErrorBoundary fullscreen onRefresh={checkForSWUpdateAndReload}>
         <ServerVersionProvider url={url} apiVersion={apiVersion}>
             <OfflineProvider
                 offlineInterface={offlineInterface}

--- a/examples/pwa-app/package.json
+++ b/examples/pwa-app/package.json
@@ -10,7 +10,7 @@
         "test": "d2-app-scripts test",
         "deploy": "d2-app-scripts deploy",
         "serve": "serve -l 5500 build/app",
-        "demo": "yarn build --force --verbose && yarn serve"
+        "demo": "yarn build --force --debug && yarn serve"
     },
     "devDependencies": {
         "@dhis2/cli-app-scripts": "^7.0.0",

--- a/sw/src/index.js
+++ b/sw/src/index.js
@@ -1,3 +1,6 @@
 export { setUpServiceWorker } from './service-worker/service-worker.js'
 export { OfflineInterface } from './offline-interface/offline-interface.js'
-export { checkForUpdates } from './lib/registration.js'
+export {
+    checkForUpdates,
+    checkForSWUpdateAndReload,
+} from './lib/registration.js'


### PR DESCRIPTION
Adds an error boundary around the app to catch errors there, and enables the top-most error boundary to check for and apply service worker updates when 'refresh' is clicked