### PR TITLE
feat(shell): add killswitch service worker

### DIFF
--- a/shell/public/service-worker.js
+++ b/shell/public/service-worker.js
@@ -1,0 +1,19 @@
+/* eslint-disable no-restricted-globals */
+
+// A simple, no-op service worker that takes immediate control and tears
+// everything down; has no fetch handler. Fixes apps with rogue service workers
+self.addEventListener('install', () => {
+    self.skipWaiting()
+})
+
+self.addEventListener('activate', async () => {
+    console.log('Removing previous service worker')
+    // Unregister, in case app doesn't
+    self.registration.unregister()
+    // Delete all caches
+    const keys = await self.caches.keys()
+    await Promise.all(keys.map(key => self.caches.delete(key)))
+    // Force refresh all windows
+    const clients = await self.clients.matchAll({ type: 'window' })
+    clients.forEach(client => client.navigate(client.url))
+})


### PR DESCRIPTION
This adds a service worker that immediately takes control and tears down a previous service worker and then itself, which will fix apps that have rogue service workers.

This is a hold over until it will be handled by #550 