### PR TITLE
feat: show error message in fatal error boundary and allow copying stack trace to clipboard

### DIFF
--- a/adapter/i18n/en.pot
+++ b/adapter/i18n/en.pot
@@ -5,11 +5,14 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-07-14T21:34:51.462Z\n"
-"PO-Revision-Date: 2021-07-14T21:34:51.462Z\n"
+"POT-Creation-Date: 2021-07-16T13:22:12.456Z\n"
+"PO-Revision-Date: 2021-07-16T13:22:12.456Z\n"
 
 msgid "An error occurred in the DHIS2 application."
 msgstr "An error occurred in the DHIS2 application."
+
+msgid "Technical details copied to clipboard"
+msgstr "Technical details copied to clipboard"
 
 msgid "Something went wrong"
 msgstr "Something went wrong"
@@ -25,6 +28,9 @@ msgstr "Show technical details"
 
 msgid "The following information may be requested by technical support."
 msgstr "The following information may be requested by technical support."
+
+msgid "Copy technical details to clipboard"
+msgstr "Copy technical details to clipboard"
 
 msgid "Please sign in"
 msgstr "Please sign in"

--- a/adapter/src/components/ErrorBoundary.js
+++ b/adapter/src/components/ErrorBoundary.js
@@ -5,14 +5,24 @@ import React, { Component } from 'react'
 import buttonStyles from './styles/Button.style'
 import styles from './styles/ErrorBoundary.style'
 
+// In order to avoid using @dhis2/ui components in the error boundary - as anything
+// that breaks within it will not be caught properly - we define a component
+// with the same styles as Button
+const UIButton = ({ children, onClick }) => (
+    <>
+        <style jsx>{buttonStyles}</style>
+        <button onClick={onClick}>{children}</button>
+    </>
+)
+
+UIButton.propTypes = {
+    children: PropTypes.node.isRequired,
+    onClick: PropTypes.func.isRequired,
+}
+
 const translatedErrorHeading = i18n.t(
     'An error occurred in the DHIS2 application.'
 )
-
-const replaceNewlinesWithBreaks = text =>
-    text
-        .split('\n')
-        .reduce((out, line, i) => [...out, line, <br key={i} />], [])
 
 export class ErrorBoundary extends Component {
     constructor(props) {
@@ -22,6 +32,7 @@ export class ErrorBoundary extends Component {
             errorInfo: null,
             drawerOpen: false,
         }
+        this.errorDetailsRef = React.createRef()
     }
 
     componentDidCatch(error, errorInfo) {
@@ -37,62 +48,64 @@ export class ErrorBoundary extends Component {
         })
     }
 
+    handleCopyErrorDetails = () => {
+        const errorDetails = this.errorDetailsRef.current.textContent
+        navigator.clipboard.writeText(errorDetails).then(() => {
+            alert(i18n.t('Technical details copied to clipboard'))
+        })
+    }
+
     render() {
-        const { children } = this.props
+        const { children, fullscreen, onRetry } = this.props
         if (this.state.error) {
             return (
-                <div
-                    className={cx('mask', {
-                        fullscreen: this.props.fullscreen,
-                    })}
-                >
+                <div className={cx('mask', { fullscreen })}>
                     <style jsx>{styles}</style>
-                    <style jsx>{buttonStyles}</style>
                     <div className="container">
-                        {/* <InfoIcon className="icon" /> */}
-                        <div className="message">
+                        <h1 className="message">
                             {i18n.t('Something went wrong')}
-                        </div>
-                        <div className="retry">
-                            <button
-                                onClick={() => {
-                                    this.props.onRetry && this.props.onRetry()
-                                }}
-                            >
-                                {i18n.t('Try again')}
-                            </button>
-                        </div>
-                        <div
+                        </h1>
+                        {onRetry && (
+                            <div className="retry">
+                                <UIButton onClick={onRetry}>
+                                    {i18n.t('Try again')}
+                                </UIButton>
+                            </div>
+                        )}
+                        <button
                             className="drawerToggle"
                             onClick={this.toggleTechInfoDrawer}
                         >
                             {this.state.drawerOpen
                                 ? i18n.t('Hide technical details')
                                 : i18n.t('Show technical details')}
-                        </div>
+                        </button>
                         <div
-                            className={
-                                this.state.drawerOpen
-                                    ? 'drawerVisible'
-                                    : 'drawerHidden'
-                            }
+                            className={cx('drawer', {
+                                hidden: !this.state.drawerOpen,
+                            })}
                         >
                             <div className="errorIntro">
-                                {translatedErrorHeading}
-                                <br />
-                                {i18n.t(
-                                    'The following information may be requested by technical support.'
-                                )}
+                                <p>{translatedErrorHeading}</p>
+                                <p>
+                                    {i18n.t(
+                                        'The following information may be requested by technical support.'
+                                    )}
+                                </p>
+                                <UIButton onClick={this.handleCopyErrorDetails}>
+                                    {i18n.t(
+                                        'Copy technical details to clipboard'
+                                    )}
+                                </UIButton>
                             </div>
-                            <div className="errorDetails">
-                                {[
-                                    replaceNewlinesWithBreaks(
-                                        this.state.error.stack +
-                                            '\n---' +
-                                            this.state.errorInfo.componentStack
-                                    ),
-                                ]}
-                            </div>
+                            <pre
+                                className="errorDetails"
+                                ref={this.errorDetailsRef}
+                            >
+                                {`${this.state.error}\n`}
+                                {this.state.error.stack}
+                                {this.state.errorInfo.componentStack}
+                            </pre>
                         </div>
                     </div>
                 </div>

--- a/adapter/src/components/styles/ErrorBoundary.style.js
+++ b/adapter/src/components/styles/ErrorBoundary.style.js
@@ -4,10 +4,12 @@ const bgColor = '#F4F6F8',
     iconColor = '#B0BEC5',
     primaryTextColor = '#000000',
     secondaryTextColor = '#494949',
-    errorColor = 'red'
+    errorColor = '#D32F2F',
+    grey050 = '#FBFCFD'
 
 export default css`
     .mask {
+        min-height: 480px;
         height: 100%;
         width: 100%;
 
@@ -18,10 +20,6 @@ export default css`
         background-color: ${bgColor};
 
         display: flex;
-
-        min-width: 640px;
-        min-height: 480px;
-
         align-items: center;
         justify-content: center;
     }
@@ -48,6 +46,8 @@ export default css`
 
     .message {
         font-size: 24px;
+        font-weight: normal;
+        margin-top: 0;
         margin-bottom: 24px;
     }
 
@@ -61,32 +61,40 @@ export default css`
         text-decoration: underline;
         cursor: pointer;
         margin-bottom: 12px;
+        background: none;
+        border: none;
     }
 
-    .drawerVisible {
+    .drawer {
+        margin: auto;
         padding: 8px;
         display: block;
-        height: 150px;
-        width: 500px;
+        height: 250px;
+        width: min(500px, 100%);
         overflow: auto;
         overflow-y: auto;
+        background: ${grey050};
         border: 1px solid ${secondaryTextColor};
         text-align: left;
     }
 
-    .drawerHidden {
+    .hidden {
         display: none;
     }
 
     .errorIntro {
-        font-size: 12px;
-        line-height: 1.2;
+        margin-bottom: 16px;
+    }
+
+    .errorIntro p {
+        margin-top: 0;
+        margin-bottom: 4px;
+        font-size: 14px;
         color: ${secondaryTextColor};
-        margin-bottom: 8px;
-        font-family: Menlo, Courier, monospace !important;
     }
 
     .errorDetails {
+        white-space: pre-wrap;
         font-size: 12px;
         line-height: 1.2;
         color: ${errorColor};


### PR DESCRIPTION
Improve error boundary by:
- Including error message in technical details drawer
- Add button to copy error message and stack trace to clipboard
- Remove min-width on error boundary mask to better support non-desktop devices
- Using `<button>` instead of `<div>` for drawer toggling

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/4295266/125957814-33f9ec89-cb84-40b9-b395-265b6a8113af.png) | ![image](https://user-images.githubusercontent.com/4295266/125957777-f22f5ff5-13d8-439f-a8c5-ed8d03ce7412.png) |
