### PR TITLE
fix: reopen indexedDB if global state resets

### DIFF
--- a/pwa/src/service-worker/service-worker.js
+++ b/pwa/src/service-worker/service-worker.js
@@ -37,11 +37,8 @@ export function setUpServiceWorker() {
     // TODO: control with env var
     self.__WB_DISABLE_DEV_LOGS = true
 
-    // Globals
+    // Globals (Note: global state resets each time SW goes idle)
 
-    // Will be populated upon activation with a promise that accesses the
-    // recorded sections IndexedDB using the `idb` library - see `createDB()`
-    self.dbPromise
     // Tracks recording states for multiple clients to handle multiple windows
     // recording simultaneously
     self.clientRecordingStates = {}


### PR DESCRIPTION
This fixes the (seemingly) intermittent `cannot read property 'put' of undefined` issue at the end of recordings: apparently, [service workers will 'sleep'/terminate when they go idle](https://web.dev/service-worker-mindset/#watch-out-for-global-state), at which point they lose their global state (but this doesn't happen while the Chrome dev tools are open, so errors can slip by in development).  IndexedDB is reopened on demand if necessary to restore the `self.dbPromise` state.