### PR TITLE
fix: simplify message payload to be compatible with firefox

### DIFF
--- a/pwa/src/offline-interface/offline-interface.js
+++ b/pwa/src/offline-interface/offline-interface.js
@@ -154,8 +154,11 @@ export class OfflineInterface {
             cleanUpListeners()
             onCompleted()
         })
-        this.offlineEvents.once(swMsgs.recordingError, ({ error }) => {
+        this.offlineEvents.once(swMsgs.recordingError, ({ msg }) => {
             cleanUpListeners()
+            // Make error out of message from SW (firefox SW message interface
+            // doesn't handle payloads other than simple objects)
+            const error = new Error(msg)
             onError(error)
         })
     }

--- a/pwa/src/service-worker/recording-mode.js
+++ b/pwa/src/service-worker/recording-mode.js
@@ -112,7 +112,7 @@ function stopRecording(error, clientId) {
             client.postMessage({
                 type: swMsgs.recordingError,
                 payload: {
-                    error,
+                    msg: error.message,
                 },
             })
         })


### PR DESCRIPTION
Firefox can't handle any special objects in the `postMessage` API between service workers and clients, which causes those messages to go quietly unsent, which sometimes manifests as failed recordings getting stuck under a loading mask. This fix simplifies the payload for recording error messages so they work on firefox