### PR TITLE
fix(cli): set test environment to node

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -60,6 +60,7 @@
     "jest": {
         "testPathIgnorePatterns": [
             "src/commands/test.js"
-        ]
+        ],
+        "testEnvironment": "node"
     }
 }


### PR DESCRIPTION
Set Jest's test environment to `node` for `cli-app-scripts` tests in order to save ~200ms per test that is otherwise wasted on initialising `jsdom`.