### PR TITLE
fix: import index css file to apply global styles

### DIFF
--- a/shell/src/index.css
+++ b/shell/src/index.css
@@ -1,17 +1,3 @@
-body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
-    monospace;
-}
-
 #dhis2-app-root {
     /* establish a stacking context for the application */
     isolation: isolate;

--- a/shell/src/index.js
+++ b/shell/src/index.js
@@ -3,6 +3,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App'
 import 'typeface-roboto'
+import './index.css'
 
 ReactDOM.render(
     <>


### PR DESCRIPTION
This is a follow-up on #631 where we applied a CSS fix for layering issues. The fix was correct, but the CSS rules weren't being applied to the app because the `index.css` file was not being imported.

So we are now importing the file and the styles from `index.css` are being applied to the app. However, this file already included some style rules, and since they weren't being applied before (due to the file not being imported) it is safer to remove them, which I've done in 4376038.