### PR TITLE
feat(cli): instance proxy server

### DIFF
--- a/adapter/src/components/LoginModal.js
+++ b/adapter/src/components/LoginModal.js
@@ -11,10 +11,11 @@ import i18n from '../locales'
 import { post } from '../utils/api'
 
 const staticUrl = process.env.REACT_APP_DHIS2_BASE_URL
+const defaultUrl = process.env.REACT_APP_DHIS2_DEFAULT_BASE_URL
 
 export const LoginModal = () => {
     const [server, setServer] = useState(
-        staticUrl || window.localStorage.DHIS2_BASE_URL || ''
+        staticUrl || defaultUrl || window.localStorage.DHIS2_BASE_URL || ''
     )
     const [username, setUsername] = useState('')
     const [password, setPassword] = useState('')

--- a/adapter/src/components/LoginModal.js
+++ b/adapter/src/components/LoginModal.js
@@ -11,11 +11,10 @@ import i18n from '../locales'
 import { post } from '../utils/api'
 
 const staticUrl = process.env.REACT_APP_DHIS2_BASE_URL
-const defaultUrl = process.env.REACT_APP_DHIS2_DEFAULT_BASE_URL
 
 export const LoginModal = () => {
     const [server, setServer] = useState(
-        staticUrl || defaultUrl || window.localStorage.DHIS2_BASE_URL || ''
+        staticUrl || window.localStorage.DHIS2_BASE_URL || ''
     )
     const [username, setUsername] = useState('')
     const [password, setPassword] = useState('')

--- a/cli/package.json
+++ b/cli/package.json
@@ -48,6 +48,7 @@
         "inquirer": "^7.3.3",
         "jest-cli": "^24.9.0",
         "lodash": "^4.17.11",
+        "node-http-proxy-json": "^0.1.9",
         "parse-author": "^2.0.0",
         "parse-gitignore": "^1.0.1",
         "styled-jsx": "<3.3.3",

--- a/cli/package.json
+++ b/cli/package.json
@@ -42,6 +42,7 @@
         "fs-extra": "^8.1.0",
         "gaze": "^1.1.3",
         "handlebars": "^4.3.3",
+        "http-proxy": "^1.18.1",
         "i18next-conv": "^9",
         "i18next-scanner": "^2.10.3",
         "inquirer": "^7.3.3",

--- a/cli/src/commands/start.js
+++ b/cli/src/commands/start.js
@@ -44,7 +44,6 @@ const handler = async ({
     if (proxy) {
         const newProxyPort = await detectPort(proxyPort)
         const proxyBaseUrl = `http://localhost:${newProxyPort}`
-        process.env.DHIS2_DEFAULT_BASE_URL = proxyBaseUrl
 
         reporter.print('')
         reporter.info('Starting proxy server...')

--- a/cli/src/lib/proxy.js
+++ b/cli/src/lib/proxy.js
@@ -100,7 +100,10 @@ exports = module.exports = ({ target, baseUrl, port, shellPort }) => {
             proxyRes.headers['set-cookie'] = sc.map(stripCookieSecure)
         }
 
-        if (proxyRes.headers['content-type']?.includes('application/json')) {
+        if (
+            proxyRes.headers['content-type'] &&
+            proxyRes.headers['content-type'].includes('application/json')
+        ) {
             transformProxyResponse(res, proxyRes, body => {
                 if (body) {
                     return transformJsonResponse(body, {

--- a/cli/src/lib/proxy.js
+++ b/cli/src/lib/proxy.js
@@ -1,0 +1,72 @@
+const url = require('url')
+const { reporter } = require('@dhis2/cli-helpers-engine')
+const httpProxy = require('http-proxy')
+
+const stripCookieSecure = cookie => {
+    return cookie
+        .split(';')
+        .filter(v => v.trim().toLowerCase() !== 'secure')
+        .join('; ')
+}
+
+const rewriteLocation = ({ location, target, baseUrl }) => {
+    const parsedLocation = url.parse(location)
+    const parsedTarget = url.parse(target)
+    const parsedBaseUrl = url.parse(baseUrl)
+
+    if (
+        parsedLocation.host === parsedTarget.host &&
+        parsedLocation.pathname.startsWith(parsedTarget.pathname)
+    ) {
+        return url.format({
+            ...parsedBaseUrl,
+            pathname: parsedLocation.pathname.replace(
+                parsedTarget.pathname,
+                ''
+            ),
+            search: parsedLocation.search,
+        })
+    }
+    return location
+}
+
+exports = module.exports = ({ target, baseUrl, port, shellPort }) => {
+    const proxyServer = httpProxy.createProxyServer({
+        target,
+        changeOrigin: true,
+        secure: false,
+        protocolRewrite: 'http',
+        cookieDomainRewrite: '',
+        cookiePathRewrite: '/',
+    })
+
+    proxyServer.on('proxyRes', (proxyRes, req, res) => {
+        if (proxyRes.headers['access-control-allow-origin']) {
+            res.setHeader(
+                'access-control-allow-origin',
+                `http://localhost:${shellPort}`
+            )
+        }
+
+        if (proxyRes.headers.location) {
+            proxyRes.headers.location = rewriteLocation({
+                location: proxyRes.headers.location,
+                target,
+                baseUrl,
+            })
+        }
+
+        const sc = proxyRes.headers['set-cookie']
+        if (Array.isArray(sc)) {
+            proxyRes.headers['set-cookie'] = sc.map(stripCookieSecure)
+        }
+    })
+
+    proxyServer.on('error', error => {
+        reporter.warn(error)
+    })
+
+    proxyServer.listen(port)
+}
+
+exports.rewriteLocation = rewriteLocation

--- a/cli/src/lib/proxy.test.js
+++ b/cli/src/lib/proxy.test.js
@@ -1,0 +1,45 @@
+const { rewriteLocation } = require('./proxy')
+
+describe('rewriteLocation', () => {
+    it('rewrites locations if they match the proxy target', () => {
+        const baseUrl = 'http://localhost:8080'
+
+        expect(
+            rewriteLocation({
+                location: 'https://play.dhis2.org/dev/login.action',
+                target: 'https://play.dhis2.org/dev',
+                baseUrl,
+            })
+        ).toBe(`${baseUrl}/login.action`)
+
+        expect(
+            rewriteLocation({
+                location: 'https://play.dhis2.org/dev/page?param=value',
+                target: 'https://play.dhis2.org/dev',
+                baseUrl,
+            })
+        ).toBe(`${baseUrl}/page?param=value`)
+    })
+
+    it('does not rewrite locations if they do not match the proxy target', () => {
+        ;[
+            {
+                location: 'https://example.com/path',
+                target: 'https://play.dhis2.org/dev',
+                baseUrl: 'http://localhost:8080',
+            },
+            {
+                location: 'https://play.dhis2.org/2.35dev',
+                target: 'https://play.dhis2.org/dev',
+                baseUrl: 'http://localhost:8080',
+            },
+            {
+                location: 'http://server.com:1234',
+                target: 'http://server.com:5678',
+                baseUrl: 'http://localhost:8080',
+            },
+        ].forEach(args => {
+            expect(rewriteLocation(args)).toBe(args.location)
+        })
+    })
+})

--- a/cli/src/lib/proxy.test.js
+++ b/cli/src/lib/proxy.test.js
@@ -1,4 +1,26 @@
-const { rewriteLocation } = require('./proxy')
+const { rewriteLocation, transformJsonResponse } = require('./proxy')
+
+describe('transformJsonResponse', () => {
+    it('rewrites URLs in responses if they match the proxy target', () => {
+        const transformedResponse = transformJsonResponse(
+            {
+                a: {
+                    b: {
+                        c: 'https://play.dhis2.org/dev/api/endpoint',
+                    },
+                },
+            },
+            {
+                target: 'https://play.dhis2.org/dev',
+                baseUrl: 'http://localhost:8080',
+            }
+        )
+
+        expect(transformedResponse.a.b.c).toBe(
+            'http://localhost:8080/api/endpoint'
+        )
+    })
+})
 
 describe('rewriteLocation', () => {
     it('rewrites locations if they match the proxy target', () => {

--- a/cli/src/lib/proxy.test.js
+++ b/cli/src/lib/proxy.test.js
@@ -41,6 +41,30 @@ describe('rewriteLocation', () => {
                 baseUrl,
             })
         ).toBe(`${baseUrl}/page?param=value`)
+
+        expect(
+            rewriteLocation({
+                location: 'https://server.com:1234',
+                target: 'https://server.com:5678',
+                baseUrl,
+            })
+        ).toBe('https://server.com:1234')
+
+        expect(
+            rewriteLocation({
+                location: 'https://server.com',
+                target: 'http://server.com',
+                baseUrl,
+            })
+        ).toBe(baseUrl)
+
+        expect(
+            rewriteLocation({
+                location: 'https://play.dhis2.org/dev/api/dev',
+                target: 'https://play.dhis2.org/dev',
+                baseUrl,
+            })
+        ).toBe(`${baseUrl}/api/dev`)
     })
 
     it('does not rewrite locations if they do not match the proxy target', () => {

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -21,5 +21,6 @@
 -   [**PWA**](pwa/pwa)
 -   [**Architecture**](architecture)
 -   [**Troubleshooting**](troubleshooting.md)
+-   [**Proxy**](proxy.md)
 -   &nbsp;
 -   [Changelog](CHANGELOG.md)

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -1,0 +1,14 @@
+# Proxy
+
+When developing against a remote instance, some browsers may block cookies due
+to the cross-site nature of requests.
+
+As a workaround, the [`start`](scripts/start.md) command provides a `--proxy`
+option. The value of this option is the remote instance that a local proxy will
+route requests to.
+
+## Usage
+
+```
+d2-app-scripts start --proxy <remote instance URL>
+```

--- a/docs/scripts/start.md
+++ b/docs/scripts/start.md
@@ -21,4 +21,6 @@ Global Options:
 Options:
   --cwd       working directory to use (defaults to cwd)
   --port, -p  The port to use when running the development server       [number]
+  --proxy, -P  The remote DHIS2 instance the proxy should point to      [string]
+  --proxyPort  The port to use when running the proxy   [number] [default: 8080]
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,8 +8,11 @@ A DHIS2 application needs to talk to a [DHIS2 server](https://www.dhis2.org/down
 
 You should specify the fully-qualified base URL of a running DHIS2 server (including the `http://` or `https://` protocol) in the **Server** field of the login dialog.
 
-Make sure that the the URL of your application (`localhost:3000` in this case) is included in the DHIS2 server's CORS whitelist (System Settings -> Access). Also ensure that the server
-you specify doesn't have any domain-restricting proxy settings (such as the `SameSite=Lax`).
+Make sure that the the URL of your application (`localhost:3000` in this case)
+is included in the DHIS2 server's CORS whitelist (System Settings -> Access). If
+your server or browser has domain-restricting settings (such as the
+`SameSite=Lax`), the [`--proxy`](proxy.md) option of the
+[`start`](scripts/start.md) command may be helpful.
 
 For testing purposes, `https://play.dhis2.org/dev` will NOT work because it is configured for secure same-site access, while `https://debug.dhis2.org/dev` should work.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9746,6 +9746,15 @@ http-proxy@^1.17.0:
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
 
+http-proxy@^1.18.1:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
+  integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
+  dependencies:
+    eventemitter3 "^4.0.0"
+    follow-redirects "^1.0.0"
+    requires-port "^1.0.0"
+
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5850,6 +5850,11 @@ buffer@^5.1.0, buffer@^5.5.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
+bufferhelper@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/bufferhelper/-/bufferhelper-0.2.1.tgz#fa74a385724a58e242f04ad6646c2366f83b913e"
+  integrity sha1-+nSjhXJKWOJC8ErWZGwjZvg7kT4=
+
 builtin-modules@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.1.0.tgz#aad97c15131eb76b65b50ef208e7584cd76a7484"
@@ -6560,7 +6565,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.5.0:
+concat-stream@^1.5.0, concat-stream@^1.5.1:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -12687,6 +12692,14 @@ node-gettext@^2.0.0:
   integrity sha512-vsHImHl+Py0vB7M2UXcFEJ5NJ3950gcja45YclBFtYxYeZiqdfQdcu+G9s4L7jpRFSh/J/7VoS3upR4JM1nS+g==
   dependencies:
     lodash.get "^4.4.2"
+
+node-http-proxy-json@^0.1.9:
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/node-http-proxy-json/-/node-http-proxy-json-0.1.9.tgz#5e744138c189ebd7e0105fe92d035a5486478cd4"
+  integrity sha512-WrKAR/y09BWaz5WqgbxuE6D/XsdhQFkLkSdnRk0a5uBKSINtApMV085MN7JMh+stiyBBltvgSR9SYVIZIpKKKQ==
+  dependencies:
+    bufferhelper "^0.2.1"
+    concat-stream "^1.5.1"
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Introduces a proxy server that can be used to test remote instances without relying on cross-site cookies.

Usage:

```
d2-app-scripts start --proxy https://debug.dhis2.org/dev
```