### PR TITLE
fix(offline-interface): prevent infinite update loop in Chrome

### DIFF
--- a/pwa/src/offline-interface/offline-interface.js
+++ b/pwa/src/offline-interface/offline-interface.js
@@ -31,8 +31,16 @@ export class OfflineInterface {
         }
 
         if ('serviceWorker' in navigator) {
-            navigator.serviceWorker.oncontrollerchange = () =>
+            let reloading
+            navigator.serviceWorker.oncontrollerchange = () => {
+                if (reloading) {
+                    // Fixes an infinite update loop when 'Update on reload' is
+                    // checked in Chrome
+                    return
+                }
+                reloading = true
                 window.location.reload()
+            }
         }
     }
     /**


### PR DESCRIPTION
Sometimes, when loading a PWA app for the first time while 'Update [SW] on reload' is checked in Chrome dev tools (in the Application tab), the app can get stuck in an infinite update loop which spams the 'Update' alert bars. This fix prevents that issue