### PR TITLE
fix: add crossorgin use-credentials to manifest.json link

### DIFF
--- a/shell/public/index.html
+++ b/shell/public/index.html
@@ -11,7 +11,7 @@
             manifest.json provides metadata used when your web app is installed on a
             user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
         -->
-        <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+        <link rel="manifest" crossorigin="use-credentials" href="%PUBLIC_URL%/manifest.json" />
         <meta name="msapplication-config" content="browserconfig.xml" />
         <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
         <link

--- a/shell/public/index.html
+++ b/shell/public/index.html
@@ -11,7 +11,11 @@
             manifest.json provides metadata used when your web app is installed on a
             user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
         -->
-        <link rel="manifest" crossorigin="use-credentials" href="%PUBLIC_URL%/manifest.json" />
+        <link
+            rel="manifest"
+            crossorigin="use-credentials"
+            href="%PUBLIC_URL%/manifest.json"
+        />
         <meta name="msapplication-config" content="browserconfig.xml" />
         <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
         <link


### PR DESCRIPTION
As spotted by @mortenoh - 

>  If the manifest requires credentials to fetch, the crossorigin attribute must be set to use-credentials, even if the manifest file is in the same origin as the current page.

([source](https://web.dev/add-manifest/#link-manifest))

Adding `crossorigin="use-credentials"` to the manifest.json link tag prevents the syntax error at character 1 we see when the browser requests the manifest.  This was caused because the manifest request was redirecting to the login page, as the cookie was stripped from that request