### PR TITLE
fix(deps): allow range for app shell's ui dependency

### DIFF
--- a/shell/package.json
+++ b/shell/package.json
@@ -16,7 +16,7 @@
         "@dhis2/app-runtime": "^3.2.0",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/pwa": "8.0.0",
-        "@dhis2/ui": "7.1.0",
+        "@dhis2/ui": "^7.1.0",
         "classnames": "^2.2.6",
         "moment": "^2.29.1",
         "prop-types": "^15.7.2",


### PR DESCRIPTION
Allows yarn to dedupe ui for app installations.