### PR TITLE
docs: typo fix

### DIFF
--- a/docs/bootstrapping.md
+++ b/docs/bootstrapping.md
@@ -1,6 +1,6 @@
 # Bootstrapping
 
-To create a new template application (or upgrade and existing React app), use the [init](scripts/init) command.
+To create a new template application (or upgrade an existing React app), use the [init](scripts/init) command.
 
 ```sh
 > d2 app scripts init my-test-app


### PR DESCRIPTION
In line 3 it was "(or update and existing one)" changed to "(or update an existing one)" ... **an** instead of **and**