### PR TITLE
fix(cli): run yarn install after fixing yarn.lock by deduplicating

### DIFF
--- a/cli/src/commands/deduplicate.js
+++ b/cli/src/commands/deduplicate.js
@@ -14,6 +14,12 @@ const handler = async ({ cwd }) => {
     const deduped = fixDuplicates(yarnLock)
     fs.writeFileSync(paths.yarnLock, deduped)
 
+    if (deduped !== yarnLock) {
+        reporter.info(
+            `Run ${chalk.bold('yarn install')} to deduplicate node_modules`
+        )
+    }
+
     const duplicates = listDuplicates(deduped)
     if (duplicates.size > 0) {
         reporter.error('Failed to deduplicate the following packages:')

--- a/cli/src/lib/validators/validateLockfile.js
+++ b/cli/src/lib/validators/validateLockfile.js
@@ -1,5 +1,5 @@
 const fs = require('fs')
-const { reporter, prompt } = require('@dhis2/cli-helpers-engine')
+const { reporter, prompt, exec } = require('@dhis2/cli-helpers-engine')
 const { listDuplicates, fixDuplicates } = require('../yarnDeduplicate')
 
 const singletonDependencies = [
@@ -52,6 +52,11 @@ exports.validateLockfile = async (pkg, { paths, offerFix = false }) => {
         }
         const dedupedYarnLock = fixDuplicates(yarnLock)
         fs.writeFileSync(paths.yarnLock, dedupedYarnLock)
+        await exec({
+            cmd: 'yarn',
+            args: ['install'],
+            cwd: paths.base,
+        })
         return listSingletonDuplicates(dedupedYarnLock).size === 0
     }
 


### PR DESCRIPTION
Run `yarn install` after deduplicating dependencies in `yarn.lock` in order to update `node_modules`.