### PR TITLE
fix(cli): wrap App component in CustomDataProvider in boilerplate test

### DIFF
--- a/cli/config/init.App.test.js
+++ b/cli/config/init.App.test.js
@@ -1,9 +1,15 @@
+import { CustomDataProvider } from '@dhis2/app-runtime'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App'
 
 it('renders without crashing', () => {
     const div = document.createElement('div')
-    ReactDOM.render(<App />, div)
+    ReactDOM.render(
+        <CustomDataProvider>
+            <App />
+        </CustomDataProvider>,
+        div
+    )
     ReactDOM.unmountComponentAtNode(div)
 })

--- a/shell/src/App.test.js
+++ b/shell/src/App.test.js
@@ -1,15 +1,9 @@
-import { CustomDataProvider } from '@dhis2/app-runtime'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App'
 
 it('renders without crashing', () => {
     const div = document.createElement('div')
-    ReactDOM.render(
-        <CustomDataProvider>
-            <App />
-        </CustomDataProvider>,
-        div
-    )
+    ReactDOM.render(<App />, div)
     ReactDOM.unmountComponentAtNode(div)
 })


### PR DESCRIPTION
In https://github.com/dhis2/app-platform/pull/677 I attempted to fix an incorrect test created when initialising an app. Unfortunately, the file I changed was the wrong one. This PR corrects `cli/config/init.App.test.js`, which is the correct file.