### PR TITLE
fix: remove lint step from publish step requirements

### DIFF
--- a/.github/workflows/dhis2-verify-lib.yml
+++ b/.github/workflows/dhis2-verify-lib.yml
@@ -73,7 +73,7 @@ jobs:
 
     publish:
         runs-on: ubuntu-latest
-        needs: [build, lint, test]
+        needs: [build, test]
         if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
         steps:
             - uses: actions/checkout@v2


### PR DESCRIPTION
Temporarily remove lint step from publish step requirements in order to be able to deploy https://github.com/dhis2/app-platform/pull/694 to beta tag.