### PR TITLE
fix(proxy): ignore nulls in transformJsonResponse

### DIFF
--- a/cli/src/lib/proxy.js
+++ b/cli/src/lib/proxy.js
@@ -54,7 +54,7 @@ const transformJsonResponse = (res, { target, baseUrl }) => {
                     transformJsonResponse(r, { target, baseUrl })
                 )
             }
-            if(res === null) {
+            if (res === null) {
                 return res
             }
             return _.transform(

--- a/cli/src/lib/proxy.js
+++ b/cli/src/lib/proxy.js
@@ -54,6 +54,9 @@ const transformJsonResponse = (res, { target, baseUrl }) => {
                     transformJsonResponse(r, { target, baseUrl })
                 )
             }
+            if(res === null) {
+                return res
+            }
             return _.transform(
                 res,
                 (result, value, key) => {

--- a/cli/src/lib/proxy.test.js
+++ b/cli/src/lib/proxy.test.js
@@ -20,6 +20,28 @@ describe('transformJsonResponse', () => {
             'http://localhost:8080/api/endpoint'
         )
     })
+
+    it('should not convert nulls to {}', () => {
+        const transformedResponse = transformJsonResponse(
+            {
+                a: {
+                    b: {
+                        c: 'https://play.dhis2.org/dev/api/endpoint',
+                    },
+                    d: null
+                },
+            },
+            {
+                target: 'https://play.dhis2.org/dev',
+                baseUrl: 'http://localhost:8080',
+            }
+        )
+
+        expect(transformedResponse.a.b.c).toBe(
+            'http://localhost:8080/api/endpoint'
+        )
+        expect(transformedResponse.a.d).toBe(null)
+    })
 })
 
 describe('rewriteLocation', () => {

--- a/cli/src/lib/proxy.test.js
+++ b/cli/src/lib/proxy.test.js
@@ -28,7 +28,7 @@ describe('transformJsonResponse', () => {
                     b: {
                         c: 'https://play.dhis2.org/dev/api/endpoint',
                     },
-                    d: null
+                    d: null,
                 },
             },
             {


### PR DESCRIPTION
A bug caused objects that had `property: null` to be converted to `{}`. This was causing the `data-entry-app` to crash, and was a pretty obscure bug to track down. The root of the issue is that `typeof null === 'object'`, and when using `_transform` with a default of `{}`, all `null`-properties were transformed to `{}`. 