### PR TITLE
feat: include plugin launch path plugin.html in built manifests [LIBS-346]

### DIFF
--- a/cli/src/lib/generateManifests.js
+++ b/cli/src/lib/generateManifests.js
@@ -108,7 +108,8 @@ module.exports = (paths, config, publicUrl) => {
         version: config.version,
         core_app: config.coreApp,
 
-        launch_path: 'index.html',
+        launch_path: paths.launchPath,
+        plugin_lauch_path: paths.pluginLaunchPath,
         default_locale: 'en',
         activities: {
             dhis: {
@@ -146,6 +147,10 @@ module.exports = (paths, config, publicUrl) => {
     // Write d2 config json
     const appConfig = { ...config }
     delete appConfig['entryPoints']
+    appConfig.entryPoints = {
+        app: paths.launchPath,
+        plugin: config.entryPoints.plugin ? paths.pluginLaunchPath : undefined
+    }
     delete appConfig['pwa']
 
     fs.writeJsonSync(paths.shellPublicConfigJson, appConfig, { spaces: 2 })

--- a/cli/src/lib/generateManifests.js
+++ b/cli/src/lib/generateManifests.js
@@ -109,7 +109,7 @@ module.exports = (paths, config, publicUrl) => {
         core_app: config.coreApp,
 
         launch_path: paths.launchPath,
-        plugin_lauch_path: paths.pluginLaunchPath,
+        plugin_launch_path: paths.pluginLaunchPath,
         default_locale: 'en',
         activities: {
             dhis: {

--- a/cli/src/lib/generateManifests.js
+++ b/cli/src/lib/generateManifests.js
@@ -149,7 +149,7 @@ module.exports = (paths, config, publicUrl) => {
     delete appConfig['entryPoints']
     appConfig.entryPoints = {
         app: paths.launchPath,
-        plugin: config.entryPoints.plugin ? paths.pluginLaunchPath : undefined
+        plugin: config.entryPoints.plugin ? paths.pluginLaunchPath : undefined,
     }
     delete appConfig['pwa']
 

--- a/cli/src/lib/paths.js
+++ b/cli/src/lib/paths.js
@@ -111,6 +111,9 @@ module.exports = (cwd = process.cwd()) => {
         ),
         buildLibBundleFile: '{name}-{version}.zip',
         buildLibBundleOutput: path.join(base),
+
+        launchPath: 'index.html',
+        pluginLaunchPath: 'plugin.html',
     }
 
     reporter.debug('PATHS', paths)

--- a/cli/src/lib/plugin/start.js
+++ b/cli/src/lib/plugin/start.js
@@ -20,7 +20,7 @@ module.exports = async ({ port, paths }) => {
             port,
             host,
             // open browser
-            open: ['/plugin.html'],
+            open: [`/${paths.pluginLaunchPath}`],
             client: {
                 logging: 'none',
                 overlay: {

--- a/cli/src/lib/plugin/webpack.config.js
+++ b/cli/src/lib/plugin/webpack.config.js
@@ -135,7 +135,7 @@ module.exports = ({ env: webpackEnv, paths }) => {
                 Object.assign(
                     {
                         inject: true,
-                        filename: 'plugin.html',
+                        filename: paths.pluginLaunchPath,
                         template: paths.shellPublicPluginHtml,
                     },
                     isProduction

--- a/cli/src/lib/pwa/injectPrecacheManifest.js
+++ b/cli/src/lib/pwa/injectPrecacheManifest.js
@@ -44,7 +44,7 @@ module.exports = function injectPrecacheManifest(paths, config) {
         globPatterns: ['**/*'],
         // Skip index.html and `static` directory;
         // CRA's workbox-webpack-plugin handles it smartly
-        globIgnores: ['static/**/*', 'index.html'],
+        globIgnores: ['static/**/*', paths.launchPath],
         additionalManifestEntries: config.pwa.caching.additionalManifestEntries,
         injectionPoint: 'self.__WB_BUILD_MANIFEST',
         // Skip revision hashing for files with hash or semver in name:


### PR DESCRIPTION
Fixes [LIBS-346](https://dhis2.atlassian.net/browse/LIBS-346)

Generate `plugin_launch_path` in `manifest.webapp` which will be served by the backend in the `api/apps` API

Also includes a modified `entrypoints` map in the `d2.config.json` output:

```json
"entrypoints": {
    "app": "index.html"
    "plugin": "plugin.html"
}
```