### PR TITLE
chore: update init files to comply with eslintReact style rules

### DIFF
--- a/cli/config/init.App.test.js
+++ b/cli/config/init.App.test.js
@@ -1,7 +1,7 @@
 import { CustomDataProvider } from '@dhis2/app-runtime'
 import React from 'react'
 import ReactDOM from 'react-dom'
-import App from './App'
+import App from './App.js'
 
 it('renders without crashing', () => {
     const div = document.createElement('div')

--- a/cli/config/init.entrypoint.js
+++ b/cli/config/init.entrypoint.js
@@ -1,6 +1,6 @@
-import React from 'react'
 import { DataQuery } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
+import React from 'react'
 import classes from './App.module.css'
 
 const query = {
@@ -13,8 +13,12 @@ const MyApp = () => (
     <div className={classes.container}>
         <DataQuery query={query}>
             {({ error, loading, data }) => {
-                if (error) return <span>ERROR</span>
-                if (loading) return <span>...</span>
+                if (error) {
+                    return <span>ERROR</span>
+                }
+                if (loading) {
+                    return <span>...</span>
+                }
                 return (
                     <>
                         <h1>


### PR DESCRIPTION
The current App.js and App.test.js templates violate our current eslintReact style rules, such that a user initiating a new app platform app and installing default style rules will get style violations: 

```
...src/App.js
   1:1   error  `react` import should occur after import of `@dhis2/d2-i18n`  import/order
  16:28  error  Expected { after 'if' condition                               curly
  17:30  error  Expected { after 'if' condition                               curly

...src/App.test.js
  4:17  error  Missing file extension "js" for "./App"  import/extensions
  ```

This PR updates the formatting to comply with current rules