### PR TITLE
chore: fix cli-style useEffect exhaustive deps warnings

### DIFF
--- a/adapter/src/components/Alerts.js
+++ b/adapter/src/components/Alerts.js
@@ -25,8 +25,8 @@ const Alerts = () => {
         )
 
     useEffect(() => {
-        if (alertManagerAlerts.length > 0 || alertStackAlerts.length > 0) {
-            setAlertStackAlerts(
+        if (alertManagerAlerts.length > 0) {
+            setAlertStackAlerts(alertStackAlerts =>
                 mergeAlertStackAlerts(alertStackAlerts, alertManagerAlerts)
             )
         }

--- a/adapter/src/components/Alerts.js
+++ b/adapter/src/components/Alerts.js
@@ -27,7 +27,10 @@ const Alerts = () => {
     useEffect(() => {
         if (alertManagerAlerts.length > 0) {
             setAlertStackAlerts((currentAlertStackAlerts) =>
-                mergeAlertStackAlerts(currentAlertStackAlerts, alertManagerAlerts)
+                mergeAlertStackAlerts(
+                    currentAlertStackAlerts,
+                    alertManagerAlerts
+                )
             )
         }
     }, [alertManagerAlerts])

--- a/adapter/src/components/Alerts.js
+++ b/adapter/src/components/Alerts.js
@@ -26,7 +26,7 @@ const Alerts = () => {
 
     useEffect(() => {
         if (alertManagerAlerts.length > 0) {
-            setAlertStackAlerts(alertStackAlerts =>
+            setAlertStackAlerts((alertStackAlerts) =>
                 mergeAlertStackAlerts(alertStackAlerts, alertManagerAlerts)
             )
         }

--- a/adapter/src/components/Alerts.js
+++ b/adapter/src/components/Alerts.js
@@ -26,8 +26,8 @@ const Alerts = () => {
 
     useEffect(() => {
         if (alertManagerAlerts.length > 0) {
-            setAlertStackAlerts((alertStackAlerts) =>
-                mergeAlertStackAlerts(alertStackAlerts, alertManagerAlerts)
+            setAlertStackAlerts((currentAlertStackAlerts) =>
+                mergeAlertStackAlerts(currentAlertStackAlerts, alertManagerAlerts)
             )
         }
     }, [alertManagerAlerts])

--- a/examples/pwa-app/src/components/VisualizationsList.js
+++ b/examples/pwa-app/src/components/VisualizationsList.js
@@ -44,7 +44,7 @@ export default function VisualizationsList() {
             }
         }
         cascadingFetch()
-    }, [])
+    }, [engine])
 
     return (
         <>


### PR DESCRIPTION
Avoid cli-style warnings and clean up useEffect calls to make logic a bit cleaner