### PR TITLE
fix(pwa): only count clients in scope

### DIFF
--- a/pwa/src/service-worker/utils.js
+++ b/pwa/src/service-worker/utils.js
@@ -104,15 +104,23 @@ export async function getClientsInfo(event) {
 
     // Include uncontrolled clients: necessary to know if there are multiple
     // tabs open upon first SW installation
-    const clientsList = await self.clients.matchAll({
-        includeUncontrolled: true,
-    })
+    const filteredClientsList = await self.clients
+        .matchAll({
+            includeUncontrolled: true,
+        })
+        .then((clientsList) =>
+            // Filter to just clients within this SW scope, because other clients
+            // on this domain but outside of SW scope are returned otherwise
+            clientsList.filter((client) =>
+                client.url.startsWith(self.registration.scope)
+            )
+        )
 
     self.clients.get(clientId).then((client) => {
         client.postMessage({
             type: swMsgs.clientsInfo,
             payload: {
-                clientsCount: clientsList.length,
+                clientsCount: filteredClientsList.length,
             },
         })
     })


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/LIBS-367

Results in correct client counts for PWA reloading purposes, otherwise all open tabs on this domain (even if they're not in scope of the SW) are returned