### PR TITLE
fix(plugins): fix file loader behavior [LIBS-399]

### DIFF
--- a/cli/config/plugin.webpack.config.js
+++ b/cli/config/plugin.webpack.config.js
@@ -105,9 +105,6 @@ module.exports = ({ env: webpackEnv, config, paths }) => {
             chunkFilename: isProduction
                 ? 'static/js/plugin-[name].[contenthash:8].chunk.js'
                 : 'static/js/plugin-[name].chunk.js',
-            // ! dhis2: this at least gets fonts to match the CRA build,
-            // but is re-outputting them
-            assetModuleFilename: 'static/media/[name].[hash][ext]',
             // TODO: investigate dev source maps here (devtoolModuleFilenameTemplate)
         },
         optimization: {
@@ -275,33 +272,25 @@ module.exports = ({ env: webpackEnv, config, paths }) => {
                                 },
                             }),
                         },
-                        // dhis2: 'asset/resource' fixes fonts, but 'file-loader' breaks css modules
-                        // when used for all asset types. So use each for respective files
-                        {
-                            test: /\.(woff|woff2|eot|ttf|otf)$/i,
-                            type: 'asset/resource',
-                            generator: {
-                                filename: 'static/media/[name].[hash][ext]',
-                            },
-                        },
                         // "file" loader makes sure those assets get served by WebpackDevServer.
                         // When you `import` an asset, you get its (virtual) filename.
                         // In production, they would get copied to the `build` folder.
                         // This loader doesn't use a "test" so it will catch all modules
                         // that fall through the other loaders.
                         {
-                            loader: require.resolve('file-loader'),
                             // Exclude `js` files to keep "css" loader working as it injects
                             // its runtime that would otherwise be processed through "file" loader.
                             // Also exclude `html` and `json` extensions so they get processed
-                            // by webpacks internal loaders.
+                            // by webpack's internal loaders.
                             exclude: [
+                                /^$/,
                                 /\.(js|mjs|jsx|ts|tsx)$/,
                                 /\.html$/,
                                 /\.json$/,
                             ],
-                            options: {
-                                name: 'static/media/[name].[hash:8].[ext]',
+                            type: 'asset/resource',
+                            generator: {
+                                filename: 'static/media/[name].[hash][ext]',
                             },
                         },
                     ],


### PR DESCRIPTION
Fixes https://dhis2.atlassian.net/browse/LIBS-399

It seems like the `file-loader` is mangling the css file from maplibre-gl (which doesn’t need compiling, strangely) and outputting all kinds of nasty junk that doesn’t work, like:
* `static/media/javascript,__webpack_public_path__=….bin`
* `static/media/svg+xml;base64,ASD:LKFDNAJKSD….bin`
* other nasty `.bin` files

In the maps app, this caused an "Filename too long" error that prevented building the app, and `svg` icons were broken when run in dev mode.

Changing to the modern asset/resource "file loader" seems to fix it with no noticeable side effects.

This configuration was originally what I used when first making plugins, but I seem to remember there was a reason not to use it -- I think it had to do with CSS modules, but this config seems to be running and building fine in the PWA test app, the LL app, and the Maps app, so I don't see any reason not to use it now 🤷‍♂️ 