### PR TITLE
fix: bump d2-i18n

### DIFF
--- a/shell/package.json
+++ b/shell/package.json
@@ -17,7 +17,7 @@
     "dependencies": {
         "@dhis2/app-adapter": "10.2.0",
         "@dhis2/app-runtime": "^3.6.1",
-        "@dhis2/d2-i18n": "^1.1.0",
+        "@dhis2/d2-i18n": "^1.1.1",
         "@dhis2/pwa": "10.2.0",
         "@dhis2/ui": "^8.6.2",
         "classnames": "^2.2.6",


### PR DESCRIPTION
This bumps d2-i18n dependency (to avoid lost translations with i18next re-initialization (https://dhis2.atlassian.net/browse/DHIS2-14132))