### PR TITLE
fix(cli): fix `--testRegex` option on `test` command

### DIFF
--- a/cli/src/commands/test.js
+++ b/cli/src/commands/test.js
@@ -57,7 +57,7 @@ const handler = async ({
                 {
                     // This arg actually expects an array
                     // https://github.com/facebook/jest/blob/21a92711a22c7b6633909fd42a87499e179d80c2/packages/jest-config/src/normalize.ts#L391-L417
-                    testPathPattern: [testRegex],
+                    testPathPattern: testRegex && [testRegex],
                     config: JSON.stringify(jestConfig),
                     updateSnapshot: !ci && updateSnapshot,
                     collectCoverage: coverage,

--- a/cli/src/commands/test.js
+++ b/cli/src/commands/test.js
@@ -55,7 +55,9 @@ const handler = async ({
 
             const result = await runCLI(
                 {
-                    testPathPattern: testRegex,
+                    // This arg actually expects an array
+                    // https://github.com/facebook/jest/blob/21a92711a22c7b6633909fd42a87499e179d80c2/packages/jest-config/src/normalize.ts#L391-L417
+                    testPathPattern: [testRegex],
                     config: JSON.stringify(jestConfig),
                     updateSnapshot: !ci && updateSnapshot,
                     collectCoverage: coverage,


### PR DESCRIPTION
Previously the path pattern would end up formatted incorrectly and would be useless, e.g. `--testRegex=Alerts` => `/A|l|e|r|t|s/`. This change makes the option work and we can filter tests! :D

I found the root of the error in the way the path patterns are built in the `jest-config` code: [`buildTestPathPattern()`](https://github.com/facebook/jest/blob/21a92711a22c7b6633909fd42a87499e179d80c2/packages/jest-config/src/normalize.ts#L391-L417)

It's surprising because [the CLI accepts a singular option](https://jestjs.io/docs/27.x/cli#--testpathpatternregex), but I guess since `@jest/core` isn't documented I shouldn't be that surprised 🤷‍♂️ 