### PR TITLE
fix: bump header bar in app shell [DHIS2-8651]

### DIFF
--- a/shell/package.json
+++ b/shell/package.json
@@ -19,7 +19,7 @@
         "@dhis2/app-runtime": "^3.6.1",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/pwa": "10.2.0",
-        "@dhis2/ui": "^8.7.4",
+        "@dhis2/ui": "^8.10.1",
         "classnames": "^2.2.6",
         "moment": "^2.29.1",
         "prop-types": "^15.7.2",

--- a/shell/package.json
+++ b/shell/package.json
@@ -19,7 +19,7 @@
         "@dhis2/app-runtime": "^3.6.1",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/pwa": "10.2.0",
-        "@dhis2/ui": "^8.6.2",
+        "@dhis2/ui": "^8.7.4",
         "classnames": "^2.2.6",
         "moment": "^2.29.1",
         "prop-types": "^15.7.2",


### PR DESCRIPTION
Bumps ui version in app shell to pick up new header bar version (bumped to latest version to pick up correct build of multi-calendar-dates package)