### PR TITLE
fix: error in non-pwa apps [LIBS-315]

### DIFF
--- a/adapter/src/components/ServerVersionProvider.js
+++ b/adapter/src/components/ServerVersionProvider.js
@@ -27,7 +27,9 @@ export const ServerVersionProvider = ({
         error: undefined,
         baseUrl: url,
     })
-    const [offlineInterfaceLoading, setOfflineInterfaceLoading] = useState(true)
+    // Skip this loading step in non-pwa apps
+    const [offlineInterfaceLoading, setOfflineInterfaceLoading] =
+        useState(pwaEnabled)
     const { systemInfo } = systemInfoState
     const { baseUrl } = baseUrlState
 
@@ -123,10 +125,12 @@ export const ServerVersionProvider = ({
     }, [appName, baseUrl])
 
     useEffect(() => {
-        offlineInterface.ready.then(() => {
-            setOfflineInterfaceLoading(false)
-        })
-    }, [offlineInterface])
+        if (pwaEnabled) {
+            offlineInterface.ready.then(() => {
+                setOfflineInterfaceLoading(false)
+            })
+        }
+    }, [offlineInterface, pwaEnabled])
 
     // This needs to come before 'loading' case to show modal at correct times
     if (systemInfoState.error || baseUrlState.error) {

--- a/pwa/src/offline-interface/offline-interface.js
+++ b/pwa/src/offline-interface/offline-interface.js
@@ -49,7 +49,6 @@ function testPWAAndSW() {
 
 /** Helper to simplify SW message sending */
 function swMessage(type, payload) {
-    console.log('SW Message:', { type, payload })
     if (!navigator.serviceWorker.controller) {
         throw new Error(
             '[Offine interface] Cannot send service worker message - no service worker is controlling this page.'
@@ -107,6 +106,7 @@ export class OfflineInterface {
         }
         navigator.serviceWorker.addEventListener('message', handleSWMessage)
 
+        // (todo: refactor to another function)
         // When this promise resolves, it indicates that a connection status
         // value has been received from the service worker and is available
         // as a property on this offlineInterface.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2225,10 +2225,10 @@
     react-docgen "^6.0.0-alpha.0"
     url-join "^4.0.1"
 
-"@dhis2/d2-i18n@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.1.0.tgz#ec777c5091f747e4c5aa4f9801c62ba4d1ef3d16"
-  integrity sha512-x3u58goDQsMfBzy50koxNrJjofJTtjRZOfz6f6Py/wMMJfp/T6vZjWMQgcfWH0JrV6d04K1RTt6bI05wqsVQvg==
+"@dhis2/d2-i18n@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.1.1.tgz#acaca32cd00b60fd6b6f1dee571f2817a50e243c"
+  integrity sha512-X0jOCIKPaYv/2z0/sdkEvcbRiYu5o1FrOwvitiS6aKFxSL/GJ872I+UdHwpWJtL+yM7Z8E1epljazW0LnHUz0Q==
   dependencies:
     i18next "^10.3"
     moment "^2.24.0"


### PR DESCRIPTION
New logic in the offline interface was causing this error: `[Offine interface] Cannot send service worker message - no service worker is controlling this page.`

This PR disables those actions in non-PWA apps and handles them in PWA apps in which the SW hasn't installed yet