### PR TITLE
fix(plugins): omit launch paths when unused [LIBS-477]

### DIFF
--- a/cli/src/lib/generateManifests.js
+++ b/cli/src/lib/generateManifests.js
@@ -108,8 +108,11 @@ module.exports = (paths, config, publicUrl) => {
         version: config.version,
         core_app: config.coreApp,
 
+        // todo: omit this for plugins without apps (LIBS-477>479)
         launch_path: paths.launchPath,
-        plugin_launch_path: paths.pluginLaunchPath,
+        plugin_launch_path: config.entryPoints.plugin
+            ? paths.pluginLaunchPath
+            : undefined,
         default_locale: 'en',
         activities: {
             dhis: {

--- a/cli/src/lib/generateManifests.js
+++ b/cli/src/lib/generateManifests.js
@@ -93,7 +93,7 @@ module.exports = (paths, config, publicUrl) => {
             },
         ],
         start_url: '.',
-        display: 'browser',
+        display: 'standalone',
         theme_color: '#ffffff',
         background_color: '#f4f6f8',
     }

--- a/cli/src/lib/parseConfig.js
+++ b/cli/src/lib/parseConfig.js
@@ -1,6 +1,6 @@
 const { reporter, chalk } = require('@dhis2/cli-helpers-engine')
 const fs = require('fs-extra')
-const { defaultsDeep, has, isPlainObject } = require('lodash')
+const { defaultsDeep, cloneDeep, has, isPlainObject } = require('lodash')
 const parseAuthorString = require('parse-author')
 
 const requiredConfigFields = {
@@ -83,7 +83,10 @@ const parseConfig = (paths) => {
 
         if (fs.existsSync(paths.config)) {
             reporter.debug('Loading d2 config at', paths.config)
-            config = require(paths.config)
+            const importedConfig = require(paths.config)
+            // Make sure not to overwrite imported object
+            // (need to use it later in generateManifest)
+            config = cloneDeep(importedConfig)
             reporter.debug('loaded', config)
         }
         if (fs.existsSync(paths.package)) {


### PR DESCRIPTION
Addresses [LIBS-477](https://dhis2.atlassian.net/browse/LIBS-478), and also sneaks in the one-line fix for [LIBS-355](https://dhis2.atlassian.net/browse/LIBS-355)

Fixing [LIBS-479](https://dhis2.atlassian.net/browse/LIBS-479) is not so straightforward because of how the plugin builds depends on the app build, and needs some more work

[LIBS-478]: https://dhis2.atlassian.net/browse/LIBS-478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIBS-355]: https://dhis2.atlassian.net/browse/LIBS-355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIBS-479]: https://dhis2.atlassian.net/browse/LIBS-479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIBS-477]: https://dhis2.atlassian.net/browse/LIBS-477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ