### PR TITLE
fix(plugins): inject precache manifest correctly [LIBS-481]

### DIFF
--- a/cli/config/plugin.webpack.config.js
+++ b/cli/config/plugin.webpack.config.js
@@ -187,8 +187,10 @@ module.exports = ({ env: webpackEnv, config, paths }) => {
                 resourceRegExp: /^\.\/locale$/,
                 contextRegExp: /moment$/,
             }),
-            // dhis2: Inject plugin static assets to the existing SW's precache manifest
-            process.env.NODE_ENV === 'production' &&
+            // dhis2: Inject plugin static assets to the existing SW's precache
+            // manifest. Don't need to do in dev because precaching isn't done
+            // in dev environments
+            isProduction &&
                 new WorkboxWebpackPlugin.InjectManifest({
                     swSrc: paths.shellBuildServiceWorker,
                     injectionPoint: 'self.__WB_PLUGIN_MANIFEST',


### PR DESCRIPTION
Addresses [LIBS-481](https://dhis2.atlassian.net/browse/LIBS-481)

This was happening because `process.env.NODE_ENV` seems to consistently be `development` during the `build` script for a reason I haven't discovered yet, despite [efforts to the contrary](https://github.com/dhis2/app-platform/blob/cc20ff17aa6ccd81a2862b7278b335c33be22dac/cli/src/lib/plugin/build.js#L3-L5)

Using `isProduction` here works because the plugin's `build` command manually sets the webpack env to 'production' [here](https://github.com/dhis2/app-platform/blob/cc20ff17aa6ccd81a2862b7278b335c33be22dac/cli/src/lib/plugin/build.js#L14-L18)

[LIBS-481]: https://dhis2.atlassian.net/browse/LIBS-481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ