### PR TITLE
fix: make loading placeholders transparent

### DIFF
--- a/adapter/src/components/LoadingMask.js
+++ b/adapter/src/components/LoadingMask.js
@@ -2,7 +2,7 @@ import { Layer, CenteredContent, CircularLoader, layers } from '@dhis2/ui'
 import React from 'react'
 
 export const LoadingMask = () => (
-    <Layer translucent level={layers.alert}>
+    <Layer level={layers.alert}>
         <CenteredContent>
             <CircularLoader />
         </CenteredContent>

--- a/shell/src/App.js
+++ b/shell/src/App.js
@@ -19,7 +19,7 @@ const App = () => (
     <AppAdapter {...appConfig}>
         <React.Suspense
             fallback={
-                <Layer translucent level={layers.alert}>
+                <Layer level={layers.alert}>
                     <CenteredContent>
                         <CircularLoader />
                     </CenteredContent>


### PR DESCRIPTION
Requested by the Analytics team (@edoardo)

From @HendrikThePendric:
> Makes perfect sense to remove it. The main purpose of the translucent layer is to visually indicate that the content below is unreachable. If there is no content below, just showing a transparent layer is preferable.

More history: [slack thread](https://dhis2.slack.com/archives/C03TYMREXDL/p1678977406092729)