### PR TITLE
fix(cli): fix envs to fix plugins in dev [LIBS-485]

### DIFF
--- a/cli/config/plugin.webpack.config.js
+++ b/cli/config/plugin.webpack.config.js
@@ -189,8 +189,10 @@ module.exports = ({ env: webpackEnv, config, paths }) => {
             }),
             // dhis2: Inject plugin static assets to the existing SW's precache
             // manifest. Don't need to do in dev because precaching isn't done
-            // in dev environments
-            isProduction &&
+            // in dev environments.
+            // Check the actual NODE_ENV because `isProduction` is currently
+            // always true due to a bug (see src/lib/plugin/start.js)
+            process.env.NODE_ENV === 'production' &&
                 new WorkboxWebpackPlugin.InjectManifest({
                     swSrc: paths.shellBuildServiceWorker,
                     injectionPoint: 'self.__WB_PLUGIN_MANIFEST',

--- a/cli/src/commands/build.js
+++ b/cli/src/commands/build.js
@@ -61,6 +61,7 @@ const handler = async ({
     const paths = makePaths(cwd)
 
     mode = mode || (dev && 'development') || getNodeEnv() || 'production'
+    process.env.BABEL_ENV = process.env.NODE_ENV = mode
     loadEnvFiles(paths, mode)
 
     reporter.print(chalk.green.bold('Build parameters:'))

--- a/cli/src/commands/start.js
+++ b/cli/src/commands/start.js
@@ -26,6 +26,7 @@ const handler = async ({
     const paths = makePaths(cwd)
 
     const mode = 'development'
+    process.env.BABEL_ENV = process.env.NODE_ENV = mode
     loadEnvFiles(paths, mode)
 
     const config = parseConfig(paths)

--- a/cli/src/lib/plugin/build.js
+++ b/cli/src/lib/plugin/build.js
@@ -1,9 +1,5 @@
 // Based on CRA build script
 
-// Do this as the first thing so that any code reading it knows the right env.
-process.env.BABEL_ENV = 'production'
-process.env.NODE_ENV = 'production'
-
 const { reporter } = require('@dhis2/cli-helpers-engine')
 const webpack = require('webpack')
 const webpackConfigFactory = require('../../../config/plugin.webpack.config')

--- a/cli/src/lib/plugin/start.js
+++ b/cli/src/lib/plugin/start.js
@@ -1,9 +1,5 @@
 // Based on CRA start script
 
-// Do this as the first thing so that any code reading it knows the right env.
-process.env.BABEL_ENV = 'development'
-process.env.NODE_ENV = 'development'
-
 const getPublicUrlOrPath = require('react-dev-utils/getPublicUrlOrPath')
 const webpack = require('webpack')
 const WebpackDevServer = require('webpack-dev-server')


### PR DESCRIPTION
Fixes [LIBS-485](https://dhis2.atlassian.net/browse/LIBS-485)

`process.env.NODE_ENV = 'development'` was leaking into the rest of the env. By fixing that, we can inject the precache manifest for plugins in production only, which fixes the error in dev

[LIBS-485]: https://dhis2.atlassian.net/browse/LIBS-485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ