### PR TITLE
fix(pwa): avoid crashing when SW is not available [LIBS-499]

### DIFF
--- a/pwa/src/offline-interface/offline-interface.js
+++ b/pwa/src/offline-interface/offline-interface.js
@@ -81,6 +81,8 @@ export class OfflineInterface {
         if (!testSWAvailable()) {
             // Make this value available for ServerVersionProvider
             this.ready = Promise.resolve()
+            // Must be connected if we can't use a SW for offline features
+            this.latestIsConnected = true
             return
         }
 
@@ -222,6 +224,10 @@ export class OfflineInterface {
      * @returns {Function} - An unsubscribe function
      */
     subscribeToDhis2ConnectionStatus({ onUpdate }) {
+        if (!testSWAvailable()) {
+            return () => undefined
+        }
+
         this.offlineEvents.on(swMsgs.dhis2ConnectionStatusUpdate, onUpdate)
         return () =>
             this.offlineEvents.off(swMsgs.dhis2ConnectionStatusUpdate, onUpdate)

--- a/pwa/src/offline-interface/offline-interface.js
+++ b/pwa/src/offline-interface/offline-interface.js
@@ -79,6 +79,8 @@ export class OfflineInterface {
         }
 
         if (!testSWAvailable()) {
+            // Make this value available for ServerVersionProvider
+            this.ready = Promise.resolve()
             return
         }
 


### PR DESCRIPTION
Fixes a `TypeError: offlineInterface.ready is undefined` error in "no-SW conditions" like private browsing in Firefox or in insecure contexts (like HTTP)

Fixes https://dhis2.atlassian.net/browse/LIBS-499