### PR TITLE
fix: move precache route handler to reenable navigation handler on login redirects [LIBS-473]

### DIFF
--- a/pwa/src/service-worker/set-up-service-worker.js
+++ b/pwa/src/service-worker/set-up-service-worker.js
@@ -67,10 +67,6 @@ export function setUpServiceWorker() {
         // Includes all built assets and index.html
         const precacheManifest = self.__WB_MANIFEST || []
 
-        // Same thing for built plugin assets
-        const pluginPrecacheManifest = self.__WB_PLUGIN_MANIFEST || []
-        precacheAndRoute(pluginPrecacheManifest)
-
         // todo: also do this routing for plugin.html
         // Extract index.html from the manifest to precache, then route
         // in a custom way
@@ -126,6 +122,7 @@ export function setUpServiceWorker() {
                     return matchPrecache(indexUrl)
                 })
         }
+        // NOTE: This route must come before any precacheAndRoute calls
         registerRoute(navigationRouteMatcher, navigationRouteHandler)
 
         // Handle the rest of files in the manifest - filter out index.html,
@@ -144,6 +141,10 @@ export function setUpServiceWorker() {
             return !entryShouldBeExcluded
         })
         precacheAndRoute(restOfManifest)
+
+        // Same thing for built plugin assets
+        const pluginPrecacheManifest = self.__WB_PLUGIN_MANIFEST || []
+        precacheAndRoute(pluginPrecacheManifest)
 
         // Similar to above; manifest injection from `workbox-build`
         // Precaches all assets in the shell's build folder except in `static`


### PR DESCRIPTION
Implements [LIBS-473](https://dhis2.atlassian.net/browse/LIBS-473)

The routing for the "plugin precache manifest" seems to be interfering with the route to handle navigation events, which prevents the service worker from passing redirect responses to the client when the user is unauthenticated. This results in seeing the login modal when visiting a PWA app while logged out, instead of being redirected to the login page

Moving the plugin precache route handler to come after the navigation handler lets the nav. route handler send redirects to the client, letting the login page be shown correctly