### PR TITLE
fix: maximum call stack size exceeded at paths.js (findYarnLock function)

### DIFF
--- a/cli/src/lib/paths.js
+++ b/cli/src/lib/paths.js
@@ -20,7 +20,7 @@ const findYarnLock = (base, rootDirectory) => {
 
 module.exports = (cwd = process.cwd()) => {
     const base = path.resolve(cwd)
-    const rootDirectory = path.parse(cwd).root;
+    const rootDirectory = path.parse(cwd).root
     const paths = {
         babelConfig: path.join(__dirname, '../../config/babel.config.js'),
         configDefaultsApp: path.join(

--- a/cli/src/lib/paths.js
+++ b/cli/src/lib/paths.js
@@ -1,6 +1,8 @@
 const fs = require('fs')
 const path = require('path')
 const { reporter } = require('@dhis2/cli-helpers-engine')
+const os = require('os');
+
 
 const shellSource = path.dirname(
     require.resolve('@dhis2/app-shell/package.json')
@@ -8,7 +10,10 @@ const shellSource = path.dirname(
 const shellAppDirname = 'src/D2App'
 
 const findYarnLock = (base) => {
-    if (base === '/') {
+    // Get the root path or drive based on the operating system
+    const rootPathByOS = os.platform() === 'win32' ? path.parse(process.cwd()).root : '/';
+
+    if (base === rootPathByOS) {
         return null
     }
 

--- a/cli/src/lib/paths.js
+++ b/cli/src/lib/paths.js
@@ -7,21 +7,20 @@ const shellSource = path.dirname(
 )
 const shellAppDirname = 'src/D2App'
 
-const findYarnLock = (base, directoryRoot) => {
-    if (base === directoryRoot) {
+const findYarnLock = (base, rootDirectory) => {
+    if (base === rootDirectory) {
         return null
     }
     const yarnLock = path.join(base, './yarn.lock')
     if (fs.existsSync(yarnLock)) {
         return yarnLock
     }
-    return findYarnLock(path.dirname(base), directoryRoot)
+    return findYarnLock(path.dirname(base), rootDirectory)
 }
 
 module.exports = (cwd = process.cwd()) => {
     const base = path.resolve(cwd)
-    // Get the root path or drive based on the operating system
-    const rootPathByOS = path.parse(cwd).root;
+    const rootDirectory = path.parse(cwd).root;
     const paths = {
         babelConfig: path.join(__dirname, '../../config/babel.config.js'),
         configDefaultsApp: path.join(
@@ -45,7 +44,7 @@ module.exports = (cwd = process.cwd()) => {
 
         base,
         package: path.join(base, './package.json'),
-        yarnLock: findYarnLock(base, rootPathByOS),
+        yarnLock: findYarnLock(base, rootDirectory),
         dotenv: path.join(base, './.env'),
         config: path.join(base, './d2.config.js'),
         readme: path.join(base, './README.md'),

--- a/cli/src/lib/paths.js
+++ b/cli/src/lib/paths.js
@@ -7,23 +7,21 @@ const shellSource = path.dirname(
 )
 const shellAppDirname = 'src/D2App'
 
-const findYarnLock = (base) => {
-    // Get the root path or drive based on the operating system
-    const rootPathByOS = path.parse(process.cwd()).root;
-
-    if (base === rootPathByOS) {
+const findYarnLock = (base, directoryRoot) => {
+    if (base === directoryRoot) {
         return null
     }
-
     const yarnLock = path.join(base, './yarn.lock')
     if (fs.existsSync(yarnLock)) {
         return yarnLock
     }
-    return findYarnLock(path.dirname(base))
+    return findYarnLock(path.dirname(base), directoryRoot)
 }
 
 module.exports = (cwd = process.cwd()) => {
     const base = path.resolve(cwd)
+    // Get the root path or drive based on the operating system
+    const rootPathByOS = path.parse(cwd).root;
     const paths = {
         babelConfig: path.join(__dirname, '../../config/babel.config.js'),
         configDefaultsApp: path.join(
@@ -47,7 +45,7 @@ module.exports = (cwd = process.cwd()) => {
 
         base,
         package: path.join(base, './package.json'),
-        yarnLock: findYarnLock(base),
+        yarnLock: findYarnLock(base, rootPathByOS),
         dotenv: path.join(base, './.env'),
         config: path.join(base, './d2.config.js'),
         readme: path.join(base, './README.md'),

--- a/cli/src/lib/paths.js
+++ b/cli/src/lib/paths.js
@@ -1,8 +1,6 @@
 const fs = require('fs')
 const path = require('path')
 const { reporter } = require('@dhis2/cli-helpers-engine')
-const os = require('os');
-
 
 const shellSource = path.dirname(
     require.resolve('@dhis2/app-shell/package.json')
@@ -11,7 +9,7 @@ const shellAppDirname = 'src/D2App'
 
 const findYarnLock = (base) => {
     // Get the root path or drive based on the operating system
-    const rootPathByOS = os.platform() === 'win32' ? path.parse(process.cwd()).root : '/';
+    const rootPathByOS = path.parse(process.cwd()).root;
 
     if (base === rootPathByOS) {
         return null


### PR DESCRIPTION
> I was facing this error when I run the d2 app scripts init pmtct to create a new app. Then I found this solution in the CoP: https://community.dhis2.org/t/rangeerror-maximum-call-stack-size-exceeded-error-when-i-run-d2-app-scripts-init-my-app/49023

> But` there we needa delete findYarnLock   function. Earlier today, when a was checking this function, I noticed that this function is in an infinite loop on windows systems because the base case inside this function is not verified only in windows.

![dhis2 error](https://github.com/dhis2/app-platform/assets/64174170/2005da07-f635-49c7-bee8-c9fd94bbb38b)

`The line if(base==="/")  I think we are checking only for mac or linux OS 'cause in windows, is if(base==="C:\\") .`
![Capture123](https://github.com/dhis2/app-platform/assets/64174170/ac2ed6e2-b145-4b3f-905e-49f423871656)

---
## I tried this solution and it worked for me.

![Capturesdsd](https://github.com/dhis2/app-platform/assets/64174170/8e3748e1-7073-4427-97f5-35ccf9dfb926)
