### PR TITLE
feat: allow for auto resizing of plugins [LIBS-487]

### DIFF
--- a/shell/src/PluginLoader.js
+++ b/shell/src/PluginLoader.js
@@ -14,19 +14,8 @@ const PluginInner = ({
     const divRef = useRef()
     const innerDivRef = useRef()
     useEffect(() => {
-        if (
-            divRef &&
-            divRef.current &&
-            (resizePluginHeight || resizePluginWidth)
-        ) {
+        if (divRef && divRef.current && resizePluginHeight) {
             const resizeObserver = new ResizeObserver(() => {
-                console.log(
-                    'height,scrollHeight,offsetWidth,scrollWidth',
-                    divRef.current.offsetHeight,
-                    divRef.current.scrollHeight,
-                    divRef.current.offsetWidth,
-                    divRef.current.scrollWidth
-                )
                 // the additional pixels currently account for possible horizontal scroll bar
                 if (resizePluginHeight) {
                     resizePluginHeight(divRef.current.offsetHeight + 20)
@@ -34,11 +23,11 @@ const PluginInner = ({
             })
             resizeObserver.observe(divRef.current)
         }
-    }, [])
+    }, [resizePluginHeight])
 
     let previousWidth
 
-    const resetWidth = () => {
+    const resetWidth = useCallback(() => {
         const currentWidth = innerDivRef.current?.scrollWidth
         if (resizePluginWidth && currentWidth) {
             if (previousWidth && Math.abs(currentWidth - previousWidth) > 20) {
@@ -47,11 +36,13 @@ const PluginInner = ({
             previousWidth = currentWidth
         }
         requestAnimationFrame(resetWidth)
-    }
+    }, [resizePluginWidth])
 
     useEffect(() => {
-        requestAnimationFrame(resetWidth)
-    }, [])
+        if (resizePluginWidth) {
+            requestAnimationFrame(resetWidth)
+        }
+    }, [resetWidth, resizePluginWidth])
 
     // inner div disables margin collapsing which would prevent computing correct height
     return (

--- a/shell/src/PluginLoader.js
+++ b/shell/src/PluginLoader.js
@@ -25,15 +25,18 @@ const PluginInner = ({
         }
     }, [resizePluginHeight])
 
-    let previousWidth
+    const previousWidth = useRef()
 
     const resetWidth = useCallback(() => {
         const currentWidth = innerDivRef.current?.scrollWidth
         if (resizePluginWidth && currentWidth) {
-            if (previousWidth && Math.abs(currentWidth - previousWidth) > 20) {
+            if (
+                previousWidth.current &&
+                Math.abs(currentWidth - previousWidth.current) > 20
+            ) {
                 resizePluginWidth(currentWidth + 20)
             }
-            previousWidth = currentWidth
+            previousWidth.current = currentWidth
         }
         requestAnimationFrame(resetWidth)
     }, [resizePluginWidth])


### PR DESCRIPTION
This adds logic to autoresize plugin wrapper components if no fixed height or width is specified. See also the corresponding change in app-runtime: https://github.com/dhis2/app-runtime/pull/1355.