### PR TITLE
fix: stop build script .d.ts file extensions

### DIFF
--- a/cli/src/lib/compiler/extensionHelpers.js
+++ b/cli/src/lib/compiler/extensionHelpers.js
@@ -1,4 +1,4 @@
-const extensionPattern = /\.[jt]sx?$/
+const extensionPattern = /(?<!\.d)\.[jt]sx?$/
 const normalizeExtension = (ext) => ext.replace(extensionPattern, '.js')
 
 module.exports.extensionPattern = extensionPattern


### PR DESCRIPTION
this is needed to stop `d2-app-scripts build` from renaming `.d.ts` to `.d.js`

related to: https://github.com/dhis2/ui/pull/1399