### PR TITLE
fix: don't open browser for plugins on start [LIBS-503]

### DIFF
--- a/cli/src/commands/start.js
+++ b/cli/src/commands/start.js
@@ -136,7 +136,7 @@ const handler = async ({
             if (config.entryPoints.plugin) {
                 const pluginPort = await detectPort(newPort + 1)
                 reporter.print(
-                    `The plugin is now available on port ${pluginPort}`
+                    `The plugin is now available on port ${pluginPort} at /${paths.pluginLaunchPath}`
                 )
                 reporter.print('')
 

--- a/cli/src/lib/plugin/start.js
+++ b/cli/src/lib/plugin/start.js
@@ -21,8 +21,6 @@ module.exports = async ({ port, config, paths }) => {
         {
             port,
             host,
-            // open browser
-            open: [`/${paths.pluginLaunchPath}`],
             client: {
                 logging: 'none',
                 overlay: {


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/LIBS-503

Plugins are generally intended to be run inside other apps and therefore require other context to run -- it doesn't make sense to open up a browser and try to run it on its own