### PR TITLE
feat: deduce base url from hosted location [LIBS-580]

### DIFF
--- a/adapter/src/components/ServerVersionProvider.js
+++ b/adapter/src/components/ServerVersionProvider.js
@@ -3,6 +3,7 @@ import { getBaseUrlByAppName, setBaseUrlByAppName } from '@dhis2/pwa'
 import PropTypes from 'prop-types'
 import React, { useEffect, useState } from 'react'
 import { get } from '../utils/api.js'
+import { getBaseUrl } from '../utils/getBaseUrl.js'
 import { parseDHIS2ServerVersion, parseVersion } from '../utils/parseVersion.js'
 import { LoadingMask } from './LoadingMask.js'
 import { LoginModal } from './LoginModal.js'
@@ -150,13 +151,15 @@ export const ServerVersionProvider = ({
 
     const serverVersion = parseDHIS2ServerVersion(systemInfo.version)
     const realApiVersion = serverVersion.minor
+    // ultimately, use an absolute URL based on hosted location
+    const finalBaseUrl = getBaseUrl(baseUrl)
 
     return (
         <Provider
             config={{
                 appName,
                 appVersion: parseVersion(appVersion),
-                baseUrl,
+                baseUrl: finalBaseUrl,
                 apiVersion: apiVersion || realApiVersion,
                 serverVersion,
                 systemInfo,

--- a/adapter/src/utils/getBaseUrl.js
+++ b/adapter/src/utils/getBaseUrl.js
@@ -1,0 +1,47 @@
+const isUrlAbsolute = (url) => {
+    // the URL constructor will throw for relative URLs
+    try {
+        new URL(url)
+        return true
+    } catch {
+        return false
+    }
+}
+
+/**
+ * Deduces the base URL for the DHIS2 instance from the location at which this
+ * app is hosted. Returns an absolute URL
+ * @param {string} defaultBaseUrl a fallback URL that will be used if the base
+ * URL can't be deduced from the window location
+ * @returns {string} an absolute base URL for the DHIS2 instance
+ */
+export const getBaseUrl = (defaultBaseUrl) => {
+    // if defaultBaseUrl is absolute, use that
+    if (isUrlAbsolute(defaultBaseUrl)) {
+        return defaultBaseUrl
+    }
+
+    const { location } = window
+    const path = location.pathname
+
+    // get penultimate 3 path elements (don't need anything before),
+    // e.g. /dev/api/apps/app-name/index.html => ['api', 'apps', 'app-name'].
+    const splitPath = path.split('/').slice(-4, -1)
+    // could be shorter than 3 elements for e.g. /dhis-web-maps/
+    const l = splitPath.length
+
+    // test for core apps
+    if (/dhis-web-.+/.test(splitPath[l - 1])) {
+        return new URL('..', location.href).href
+    }
+
+    // test for custom apps
+    if (splitPath[l - 3] === 'api' && splitPath[l - 2] === 'apps') {
+        return new URL('../../..', location.href).href
+    }
+
+    // todo: handle path for global shell
+
+    // otherwise, return absolute version of default
+    return new URL(defaultBaseUrl, location.href).href
+}

--- a/adapter/src/utils/getBaseUrl.test.js
+++ b/adapter/src/utils/getBaseUrl.test.js
@@ -1,0 +1,61 @@
+import { getBaseUrl } from './getBaseUrl.js'
+
+const testOrigin = 'https://debug.dhis2.org'
+// { [testPath]: expectedPath }
+const testPaths = {
+    '/dev/api/apps/simple-app/index.html': '/dev/',
+    '/analytics_dev/dhis-web-maps/plugin.html': '/analytics_dev/',
+    '/dhis-web-line-listing/index.html': '/',
+    '/dhis-web-user-settings/': '/',
+    '/hmis/staging/v41/api/apps/WHO-Data-Quality-App/app.html':
+        '/hmis/staging/v41/',
+}
+
+const windowLocationMock = jest
+    .spyOn(window, 'location', 'get')
+    .mockImplementation(() => ({
+        href: 'https://debug.dhis2.org/dev/',
+        pathname: '/dev/',
+    }))
+
+afterEach(() => {
+    jest.clearAllMocks()
+})
+
+test('an absolute URL is used if provided as the default', () => {
+    const testBaseUrl = 'http://localhost:8080/hmis/long/path/dev'
+
+    const url = getBaseUrl(testBaseUrl)
+
+    expect(url).toBe(testBaseUrl)
+})
+
+describe('location variants', () => {
+    const defaultRelativeBaseUrl = '..'
+
+    for (const [testPath, expectedPath] of Object.entries(testPaths)) {
+        test(testPath, () => {
+            windowLocationMock.mockImplementation(() => ({
+                pathname: testPath,
+                href: testOrigin + testPath,
+            }))
+
+            const url = getBaseUrl(defaultRelativeBaseUrl)
+
+            expect(url).toBe(testOrigin + expectedPath)
+        })
+    }
+})
+
+test("if the function doesn't match a pattern, it falls back to the provided default", () => {
+    const relativeDefaultBaseUrl = '../../..'
+    const testPath = '/not/a/recognized/path/index.html'
+    windowLocationMock.mockImplementation(() => ({
+        pathname: testPath,
+        href: testOrigin + testPath,
+    }))
+
+    const url = getBaseUrl(relativeDefaultBaseUrl)
+
+    expect(url).toBe(testOrigin + '/not/')
+})


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/LIBS-580

Computes a base URL from the location the app is hosted. This should be relatively stable, and there are only currently two possibilities (there may be more with the global shell work)

Tested out existing cases to make sure they still work by deploying a build of the simple example app (custom app) and by injecting this build of the Adapter into a core app and deploying that (with a console log added), but have not yet done a test of bundling a previously unbundled app

<img width="1770" alt="Screenshot 2024-02-23 at 8 22 12 PM" src="https://github.com/dhis2/app-platform/assets/49666798/228588f2-fc1a-4962-90dd-9365aefc7189">

<img width="1770" alt="Screenshot 2024-02-23 at 8 40 42 PM" src="https://github.com/dhis2/app-platform/assets/49666798/3ecfb1cb-3d5d-4932-99d4-bd3f89feee72">
