### PR TITLE
feat: add redirect to safe login mode for login apps

### DIFF
--- a/adapter/i18n/en.pot
+++ b/adapter/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-02-08T14:36:41.461Z\n"
-"PO-Revision-Date: 2023-02-08T14:36:41.461Z\n"
+"POT-Creation-Date: 2024-03-14T15:31:40.141Z\n"
+"PO-Revision-Date: 2024-03-14T15:31:40.141Z\n"
 
 msgid "Save your data"
 msgstr "Save your data"
@@ -44,6 +44,9 @@ msgstr "Try again"
 
 msgid "Something went wrong"
 msgstr "Something went wrong"
+
+msgid "Redirect to safe login mode"
+msgstr "Redirect to safe login mode"
 
 msgid "Hide technical details"
 msgstr "Hide technical details"

--- a/adapter/src/components/ErrorBoundary.js
+++ b/adapter/src/components/ErrorBoundary.js
@@ -63,11 +63,13 @@ export class ErrorBoundary extends Component {
 
     handleSafeLoginRedirect = () => {
         window.location.href =
-            this.props.url + '/dhis-web-commons/security/login.action'
+            this.props.baseURL +
+            (this.props.baseURL.endsWith('/') ? '' : '/') +
+            'dhis-web-commons/security/login.action'
     }
 
     render() {
-        const { children, fullscreen, onRetry, login, url } = this.props
+        const { children, fullscreen, onRetry, login, baseURL } = this.props
 
         if (this.state.error) {
             if (this.props.plugin) {
@@ -94,7 +96,7 @@ export class ErrorBoundary extends Component {
                         <h1 className="message">
                             {i18n.t('Something went wrong')}
                         </h1>
-                        {login && url && (
+                        {login && baseURL && (
                             <div className="retry">
                                 <UIButton
                                     onClick={this.handleSafeLoginRedirect}
@@ -156,10 +158,10 @@ export class ErrorBoundary extends Component {
 
 ErrorBoundary.propTypes = {
     children: PropTypes.node.isRequired,
+    baseURL: PropTypes.string,
     fullscreen: PropTypes.bool,
     login: PropTypes.bool,
     plugin: PropTypes.bool,
-    url: PropTypes.string,
     onPluginError: PropTypes.func,
     onRetry: PropTypes.func,
 }

--- a/adapter/src/components/ErrorBoundary.js
+++ b/adapter/src/components/ErrorBoundary.js
@@ -61,8 +61,14 @@ export class ErrorBoundary extends Component {
         })
     }
 
+    handleSafeLoginRedirect = () => {
+        window.location.href =
+            this.props.url + '/dhis-web-commons/security/login.action'
+    }
+
     render() {
-        const { children, fullscreen, onRetry } = this.props
+        const { children, fullscreen, onRetry, login, url } = this.props
+
         if (this.state.error) {
             if (this.props.plugin) {
                 return (
@@ -88,6 +94,15 @@ export class ErrorBoundary extends Component {
                         <h1 className="message">
                             {i18n.t('Something went wrong')}
                         </h1>
+                        {login && url && (
+                            <div className="retry">
+                                <UIButton
+                                    onClick={this.handleSafeLoginRedirect}
+                                >
+                                    {i18n.t('Redirect to safe login mode')}
+                                </UIButton>
+                            </div>
+                        )}
                         {onRetry && (
                             <div className="retry">
                                 <UIButton onClick={onRetry}>
@@ -142,7 +157,9 @@ export class ErrorBoundary extends Component {
 ErrorBoundary.propTypes = {
     children: PropTypes.node.isRequired,
     fullscreen: PropTypes.bool,
+    login: PropTypes.bool,
     plugin: PropTypes.bool,
+    url: PropTypes.string,
     onPluginError: PropTypes.func,
     onRetry: PropTypes.func,
 }

--- a/adapter/src/components/LoginAppWrapper.js
+++ b/adapter/src/components/LoginAppWrapper.js
@@ -21,7 +21,7 @@ export const LoginAppWrapper = ({ url, children }) => {
                 <ErrorBoundary
                     onRetry={() => window.location.reload()}
                     login={true}
-                    url={url}
+                    baseURL={url}
                 >
                     {children}
                 </ErrorBoundary>

--- a/adapter/src/components/LoginAppWrapper.js
+++ b/adapter/src/components/LoginAppWrapper.js
@@ -6,7 +6,7 @@ import { ErrorBoundary } from './ErrorBoundary.js'
 import { LoadingMask } from './LoadingMask.js'
 import { styles } from './styles/AppWrapper.style.js'
 
-export const LoginAppWrapper = ({ children }) => {
+export const LoginAppWrapper = ({ url, children }) => {
     const { loading: localeLoading } = useSystemDefaultLocale()
     // cannot check current user for a loginApp (no api/me)
 
@@ -18,7 +18,11 @@ export const LoginAppWrapper = ({ children }) => {
         <div className="app-shell-adapter">
             <style jsx>{styles}</style>
             <div className="app-shell-app">
-                <ErrorBoundary onRetry={() => window.location.reload()}>
+                <ErrorBoundary
+                    onRetry={() => window.location.reload()}
+                    login={true}
+                    url={url}
+                >
                     {children}
                 </ErrorBoundary>
             </div>
@@ -29,4 +33,5 @@ export const LoginAppWrapper = ({ children }) => {
 
 LoginAppWrapper.propTypes = {
     children: PropTypes.node,
+    url: PropTypes.string,
 }

--- a/adapter/src/index.js
+++ b/adapter/src/index.js
@@ -31,6 +31,8 @@ const AppAdapter = ({
                     window.location.reload()
                 }}
                 plugin={false}
+                login={true}
+                url={url}
             >
                 <ServerVersionProvider
                     appName={appName}
@@ -41,7 +43,7 @@ const AppAdapter = ({
                     loginApp={loginApp}
                     plugin={false}
                 >
-                    <LoginAppWrapper>{children}</LoginAppWrapper>
+                    <LoginAppWrapper url={url}>{children}</LoginAppWrapper>
                 </ServerVersionProvider>
             </ErrorBoundary>
         )

--- a/adapter/src/index.js
+++ b/adapter/src/index.js
@@ -32,7 +32,7 @@ const AppAdapter = ({
                 }}
                 plugin={false}
                 login={true}
-                url={url}
+                baseURL={url}
             >
                 <ServerVersionProvider
                     appName={appName}


### PR DESCRIPTION
Adds login-app-specific error boundary that shows button to redirect to "safe" login page:

<img width="910" alt="image" src="https://github.com/dhis2/app-platform/assets/18490902/36996d57-4548-48d3-8dc4-d24dce262371">
