### PR TITLE
fix(deps): resolution for app-runtime alpha

### DIFF
--- a/adapter/package.json
+++ b/adapter/package.json
@@ -38,7 +38,7 @@
         "test": "d2-app-scripts test"
     },
     "peerDependencies": {
-        "@dhis2/app-runtime": "alpha",
+        "@dhis2/app-runtime": "^3.10.4-alpha.1",
         "@dhis2/d2-i18n": "^1",
         "@dhis2/ui": ">=9.2.0",
         "classnames": "^2",

--- a/shell/package.json
+++ b/shell/package.json
@@ -16,7 +16,7 @@
     },
     "dependencies": {
         "@dhis2/app-adapter": "11.1.1-alpha.1",
-        "@dhis2/app-runtime": "alpha",
+        "@dhis2/app-runtime": "^3.10.4-alpha.1",
         "@dhis2/d2-i18n": "^1.1.1",
         "@dhis2/pwa": "11.1.1-alpha.1",
         "@dhis2/ui": "^9.2.0",
@@ -31,6 +31,9 @@
         "styled-jsx": "^4.0.1",
         "typeface-roboto": "^0.0.75",
         "typescript": "^3.6.3"
+    },
+    "resolutions": {
+        "@dhis2/app-runtime": "^3.10.4-alpha.1"
     },
     "scripts": {
         "start": "react-scripts start",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1913,7 +1913,7 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/app-runtime@alpha":
+"@dhis2/app-runtime@^3.10.4-alpha.1":
   version "3.10.4-alpha.1"
   resolved "https://registry.yarnpkg.com/@dhis2/app-runtime/-/app-runtime-3.10.4-alpha.1.tgz#241aad114dba03666a4d06e3dbbf69ea5fd13250"
   integrity sha512-NXW/FHERdT3aShO9hokZai9OmaBn4ZymFrQWyowkjGc71ZCdr4VrdGDFyZdrqnyjNiysIa1mxUMThygXMGO8Kg==


### PR DESCRIPTION
The dependency loop for `@dhis2/app-service-data` is fixed by the change in the alpha branch of `@dhis2/app-runtime`, but `@dhis2/ui` depends on main release of `@dhis2/app-runtime` as well, which then ends up running into same the `app-runtime` loop -- hopefully this resolution works for NPM to fix the loop from the UI dependency on app runtime