### PR TITLE
fix(deps): use exact version of workbox to avoid broken 6.6.1 version

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -67,8 +67,8 @@
         "terser-webpack-plugin": "^5.3.1",
         "webpack": "^5.41.1",
         "webpack-dev-server": "^4.7.4",
-        "workbox-build": "^6.1.5",
-        "workbox-webpack-plugin": "^6.5.4"
+        "workbox-build": "6.5.4",
+        "workbox-webpack-plugin": "6.5.4"
     },
     "bin": {
         "d2-app-scripts": "./bin/d2-app-scripts"

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -17,10 +17,10 @@
     },
     "dependencies": {
         "idb": "^6.0.0",
-        "workbox-core": "^6.1.5",
-        "workbox-precaching": "^6.1.5",
-        "workbox-routing": "^6.1.5",
-        "workbox-strategies": "^6.1.5"
+        "workbox-core": "6.5.4",
+        "workbox-precaching": "6.5.4",
+        "workbox-routing": "6.5.4",
+        "workbox-strategies": "6.5.4"
     },
     "main": "./build/cjs/index.js",
     "module": "./build/es/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14179,7 +14179,7 @@ workbox-broadcast-update@6.5.4:
   dependencies:
     workbox-core "6.5.4"
 
-workbox-build@6.5.4, workbox-build@^6.1.5:
+workbox-build@6.5.4:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/workbox-build/-/workbox-build-6.5.4.tgz#7d06d31eb28a878817e1c991c05c5b93409f0389"
   integrity sha512-kgRevLXEYvUW9WS4XoziYqZ8Q9j/2ziJYEtTrjdz5/L/cTUa2XfyMP2i7c3p34lgqJ03+mTiz13SdFef2POwbA==
@@ -14229,7 +14229,7 @@ workbox-cacheable-response@6.5.4:
   dependencies:
     workbox-core "6.5.4"
 
-workbox-core@6.5.4, workbox-core@^6.1.5:
+workbox-core@6.5.4:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/workbox-core/-/workbox-core-6.5.4.tgz#df48bf44cd58bb1d1726c49b883fb1dffa24c9ba"
   integrity sha512-OXYb+m9wZm8GrORlV2vBbE5EC1FKu71GGp0H4rjmxmF4/HLbMCoTFws87M3dFwgpmg0v00K++PImpNQ6J5NQ6Q==
@@ -14259,7 +14259,7 @@ workbox-navigation-preload@6.5.4:
   dependencies:
     workbox-core "6.5.4"
 
-workbox-precaching@6.5.4, workbox-precaching@^6.1.5:
+workbox-precaching@6.5.4:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/workbox-precaching/-/workbox-precaching-6.5.4.tgz#740e3561df92c6726ab5f7471e6aac89582cab72"
   integrity sha512-hSMezMsW6btKnxHB4bFy2Qfwey/8SYdGWvVIKFaUm8vJ4E53JAY+U2JwLTRD8wbLWoP6OVUdFlXsTdKu9yoLTg==
@@ -14287,14 +14287,14 @@ workbox-recipes@6.5.4:
     workbox-routing "6.5.4"
     workbox-strategies "6.5.4"
 
-workbox-routing@6.5.4, workbox-routing@^6.1.5:
+workbox-routing@6.5.4:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/workbox-routing/-/workbox-routing-6.5.4.tgz#6a7fbbd23f4ac801038d9a0298bc907ee26fe3da"
   integrity sha512-apQswLsbrrOsBUWtr9Lf80F+P1sHnQdYodRo32SjiByYi36IDyL2r7BH1lJtFX8fwNHDa1QOVY74WKLLS6o5Pg==
   dependencies:
     workbox-core "6.5.4"
 
-workbox-strategies@6.5.4, workbox-strategies@^6.1.5:
+workbox-strategies@6.5.4:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/workbox-strategies/-/workbox-strategies-6.5.4.tgz#4edda035b3c010fc7f6152918370699334cd204d"
   integrity sha512-DEtsxhx0LIYWkJBTQolRxG4EI0setTJkqR4m7r4YpBdxtWJH1Mbg01Cj8ZjNOO8etqfA3IZaOPHUxCs8cBsKLw==
@@ -14314,7 +14314,7 @@ workbox-sw@6.5.4:
   resolved "https://registry.yarnpkg.com/workbox-sw/-/workbox-sw-6.5.4.tgz#d93e9c67924dd153a61367a4656ff4d2ae2ed736"
   integrity sha512-vo2RQo7DILVRoH5LjGqw3nphavEjK4Qk+FenXeUsknKn14eCNedHOXWbmnvP4ipKhlE35pvJ4yl4YYf6YsJArA==
 
-workbox-webpack-plugin@^6.4.1, workbox-webpack-plugin@^6.5.4:
+workbox-webpack-plugin@6.5.4, workbox-webpack-plugin@^6.4.1:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/workbox-webpack-plugin/-/workbox-webpack-plugin-6.5.4.tgz#baf2d3f4b8f435f3469887cf4fba2b7fac3d0fd7"
   integrity sha512-LmWm/zoaahe0EGmMTrSLUi+BjyR3cdGEfU3fS6PN1zKFYbqAKuQ+Oy/27e4VSXsyIwAw8+QDfk1XHNGtZu9nQg==


### PR DESCRIPTION
**Update:** tested this out on alpha, and it's not successful because `react-scripts` still has a dependency on `workbox-webpack-plugin@^6.4.1`, which resolves to the broken 6.6.1 upon installation of the CLI

---

Currently, new installations of `cli-app-scripts` end up throwing an error on Node 14:
```
error workbox-webpack-plugin@6.6.1: The engine "node" is incompatible with this module. Expected version ">=16.0.0". Got "14.21.3"
```
This seems to be due to a broken release of `workbox` that should have been a major version, but it gets installed because of the ^6 dependency in the platform

The 6.6.1 release is now flagged as `deprecated` when installed on Node 16, and seems to be removed from the [release history](https://github.com/GoogleChrome/workbox/releases), which also shows the next major release as having the exact same breaking change in question (v7: Node 16 is now the minimum version). There is also a reported [bug](https://github.com/GoogleChrome/workbox/issues/3220)

This will avoid increasing the minimum Node requirement to 16 for app-platform