### PR TITLE
feat: start plugin and app separately [LIBS-391] [LIBS-392]

### DIFF
--- a/cli/config/plugin.webpack.config.js
+++ b/cli/config/plugin.webpack.config.js
@@ -103,7 +103,7 @@ module.exports = ({ env: webpackEnv, config, paths }) => {
             path: paths.shellBuildOutput,
             filename: isProduction
                 ? 'static/js/plugin-[name].[contenthash:8].js'
-                : 'static/js/plugin.bundle.js',
+                : 'static/js/plugin-[name].bundle.js',
             chunkFilename: isProduction
                 ? 'static/js/plugin-[name].[contenthash:8].chunk.js'
                 : 'static/js/plugin-[name].chunk.js',
@@ -192,9 +192,7 @@ module.exports = ({ env: webpackEnv, config, paths }) => {
             // dhis2: Inject plugin static assets to the existing SW's precache
             // manifest. Don't need to do in dev because precaching isn't done
             // in dev environments.
-            // Check the actual NODE_ENV because `isProduction` is currently
-            // always true due to a bug (see src/lib/plugin/start.js)
-            process.env.NODE_ENV === 'production' &&
+            isProduction &&
                 new WorkboxWebpackPlugin.InjectManifest({
                     swSrc: paths.shellBuildServiceWorker,
                     injectionPoint: 'self.__WB_PLUGIN_MANIFEST',

--- a/cli/src/commands/start.js
+++ b/cli/src/commands/start.js
@@ -186,6 +186,16 @@ const command = {
             description: 'The port to use when running the proxy',
             default: 8080,
         },
+        // todo: change with Vite
+        app: {
+            type: 'boolean',
+            description:
+                'Start a dev server for just the app entrypoint (instead of both app and plugin, if this app has a plugin)',
+        },
+        plugin: {
+            type: 'boolean',
+            description: 'Start a dev server for just the plugin entrypoint',
+        },
     },
     handler,
 }

--- a/cli/src/commands/start.js
+++ b/cli/src/commands/start.js
@@ -23,6 +23,7 @@ const handler = async ({
     shell: shellSource,
     proxy,
     proxyPort,
+    plugin: shouldStartPlugin,
 }) => {
     const paths = makePaths(cwd)
 
@@ -125,29 +126,24 @@ const handler = async ({
 
             reporter.print('')
             reporter.info('Starting development server...')
+
+            // start either plugin or app, based on --plugin flag
+            if (shouldStartPlugin) {
+                reporter.print(
+                    `The plugin is now available on port ${newPort} at /${paths.pluginLaunchPath}`
+                )
+                reporter.print('')
+                await plugin.start({ port: newPort })
+                return
+            }
+
             reporter.print(
                 `The app ${chalk.bold(
                     config.name
                 )} is now available on port ${newPort}`
             )
             reporter.print('')
-
-            const shellStartPromise = shell.start({ port: newPort })
-
-            if (config.entryPoints.plugin) {
-                const pluginPort = await detectPort(newPort + 1)
-                reporter.print(
-                    `The plugin is now available on port ${pluginPort} at /${paths.pluginLaunchPath}`
-                )
-                reporter.print('')
-
-                await Promise.all([
-                    shellStartPromise,
-                    plugin.start({ port: pluginPort }),
-                ])
-            } else {
-                await shellStartPromise
-            }
+            await shell.start({ port: newPort })
         },
         {
             name: 'start',

--- a/cli/src/lib/plugin/start.js
+++ b/cli/src/lib/plugin/start.js
@@ -7,9 +7,7 @@ const webpackConfigFactory = require('../../../config/plugin.webpack.config')
 
 module.exports = async ({ port, config, paths }) => {
     const webpackConfig = webpackConfigFactory({
-        // todo: change to development, but this creates a compilation error
-        // can read more here: https://github.com/dhis2/app-platform/pull/740/files/69411d9b61845cbd0d053f2313bdbd4e80fdf2ac#r1031576956
-        env: 'production',
+        env: 'development',
         config,
         paths,
     })

--- a/docs/scripts/start.md
+++ b/docs/scripts/start.md
@@ -23,4 +23,7 @@ Options:
   --port, -p  The port to use when running the development server       [number]
   --proxy, -P  The remote DHIS2 instance the proxy should point to      [string]
   --proxyPort  The port to use when running the proxy   [number] [default: 8080]
+  --app        Start a dev server for just the app entrypoint (instead of both
+               app and plugin, if this app has a plugin)               [boolean]
+  --plugin     Start a dev server for just the plugin entrypoint       [boolean]
 ```

--- a/examples/pwa-app/d2.config.js
+++ b/examples/pwa-app/d2.config.js
@@ -16,6 +16,7 @@ const config = {
         // Uncomment this to test plugin builds:
         // plugin: './src/components/VisualizationsList.js',
     },
+    skipPluginLogic: true,
 }
 
 module.exports = config


### PR DESCRIPTION
Addresses [LIBS-391](https://dhis2.atlassian.net/browse/LIBS-391) and [LIBS-392](https://dhis2.atlassian.net/browse/LIBS-392):
1. Runs a dev build with `yarn start` instead of a minified production build -- this was fixed by allowing multiple chunks to be made in the dev build
2. Allows starting the app and the plugin separately -- the default behavior is still the same to avoid a breaking change, but you can now run `yarn start --app` to start just the app or `yarn start --plugin` to start just the plugin
    1. With the Vite changes, I think I will change the default to be to start just the app, then a user can pass the plugin flag to start just the plugin. It doesn't seem necessary to run both

Minified before & after:
![minified-before](https://github.com/dhis2/app-platform/assets/49666798/2648a117-4268-4132-a543-2fac1b6601aa)
![minified-after](https://github.com/dhis2/app-platform/assets/49666798/e84f2358-9831-4060-9bfd-0cd57088c940)

New start script options:
![new-start-script-options](https://github.com/dhis2/app-platform/assets/49666798/2d37857b-2f66-49ed-88fc-e44a84995925)


[LIBS-391]: https://dhis2.atlassian.net/browse/LIBS-391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIBS-392]: https://dhis2.atlassian.net/browse/LIBS-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ