### PR TITLE
fix: don't start plugins for apps without a plugin entrypoint

### DIFF
--- a/cli/src/commands/start.js
+++ b/cli/src/commands/start.js
@@ -145,7 +145,10 @@ const handler = async ({
                 startPromises.push(shell.start({ port: newPort }))
             }
 
-            if (shouldStartBoth || shouldStartOnlyPlugin) {
+            if (
+                config.entryPoints.plugin &&
+                (shouldStartBoth || shouldStartOnlyPlugin)
+            ) {
                 reporter.print(
                     `The plugin is now available on port ${newPort} at /${paths.pluginLaunchPath}`
                 )


### PR DESCRIPTION
Missed this in the previous PR -- pointed out by Edoardo:

![Screenshot 2024-05-31 at 13 42 49](https://github.com/dhis2/app-platform/assets/49666798/3c7a8d64-c892-4487-9a46-de70f02a5653)
