### PR TITLE
fix: clean up for plugins [LIBS-620]

### DIFF
--- a/adapter/src/index.js
+++ b/adapter/src/index.js
@@ -92,7 +92,7 @@ AppAdapter.propTypes = {
     parentAlertsAdd: PropTypes.func,
     plugin: PropTypes.bool,
     pwaEnabled: PropTypes.bool,
-    showAlertsInPlugin: PropTypes.func,
+    showAlertsInPlugin: PropTypes.bool,
     url: PropTypes.string,
     onPluginError: PropTypes.func,
 }

--- a/shell/src/PluginLoader.js
+++ b/shell/src/PluginLoader.js
@@ -196,7 +196,7 @@ export const PluginLoader = ({ config, requiredProps, D2App }) => {
         >
             <React.Suspense
                 fallback={
-                    <Layer translucent level={layers.alert}>
+                    <Layer level={layers.alert}>
                         <CenteredContent>
                             <CircularLoader />
                         </CenteredContent>

--- a/shell/src/PluginLoader.js
+++ b/shell/src/PluginLoader.js
@@ -66,7 +66,7 @@ const PluginInner = ({
 PluginInner.propTypes = {
     D2App: PropTypes.object,
     config: PropTypes.object,
-    propsFromParent: PropTypes.array,
+    propsFromParent: PropTypes.object,
     resizePluginHeight: PropTypes.func,
     resizePluginWidth: PropTypes.func,
 }

--- a/shell/src/PluginLoader.js
+++ b/shell/src/PluginLoader.js
@@ -50,7 +50,7 @@ const PluginInner = ({
     // inner div disables margin collapsing which would prevent computing correct height
     return (
         <div ref={divRef}>
-            <div style={{ display: 'flex', width: 'fitContent' }}>
+            <div>
                 <div id="innerDiv" ref={innerDivRef}>
                     <D2App
                         config={config}


### PR DESCRIPTION
This does some clean up for issues noticed by @edoardo when testing plugins implementation:

### CSS

- removes some styling on one of the outer divs for plugins (https://github.com/dhis2/app-platform/commit/e4b73d7bc95b40333cb1a9f0a9c6e70f612b3495). I have tested with auto resizing plugins, and the `flex` styling seems to not have an effect. The `fitContent` styling is not being applied anyway.
- removes `translucent` from plugin Loading layer (https://github.com/dhis2/app-platform/commit/997254f68a30461c460b3fc4a0dbdd6ccb6b88ee). We decided to do this before (https://github.com/dhis2/app-platform/pull/795), but it might have got lost in merge/redoing the plugin loading logic.

### Prop type checking
- fixes some invalid prop types checking (https://github.com/dhis2/app-platform/commit/6af10641e5953f3e0aab7b749273ba2d3dfbc60e)
