### PR TITLE
fix: do not encode username, password [LIBS-625]

### DIFF
--- a/adapter/src/components/LoginModal.js
+++ b/adapter/src/components/LoginModal.js
@@ -40,8 +40,8 @@ const loginWithNewEndpoints = async ({
         await postJSON(
             `${server}/api/auth/login`,
             JSON.stringify({
-                username: encodeURIComponent(username),
-                password: encodeURIComponent(password),
+                username,
+                password,
             })
         )
         window.location.reload()


### PR DESCRIPTION
This fixes an issue where the username and password were being encoded before being passed to api/login. 

I had copied some of the code from the old login logic, but that is using `Content-Type:application/x-www-form-urlencoded`, so requires encoding, whereas the post with json body, does not need that encoding 🤦‍♂️.

**Before**
payload like `{"username": "admin", "password":  "District1%23"}`

**After**
payload like `{"username": "admin", "password":  "District1#"}`