### PR TITLE
fix: fixed plugin dimensions [LIBS-634]

### DIFF
--- a/shell/src/PluginLoader.js
+++ b/shell/src/PluginLoader.js
@@ -4,7 +4,7 @@ import postRobot from 'post-robot'
 import PropTypes from 'prop-types'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 
-const PluginInner = ({
+const PluginResizeInner = ({
     D2App,
     config,
     propsFromParent,
@@ -60,6 +60,41 @@ const PluginInner = ({
                 </div>
             </div>
         </div>
+    )
+}
+
+PluginResizeInner.propTypes = {
+    D2App: PropTypes.object,
+    config: PropTypes.object,
+    propsFromParent: PropTypes.object,
+    resizePluginHeight: PropTypes.func,
+    resizePluginWidth: PropTypes.func,
+}
+
+const PluginInner = ({
+    D2App,
+    config,
+    propsFromParent,
+    resizePluginHeight,
+    resizePluginWidth,
+}) => {
+    if (!resizePluginHeight && !resizePluginWidth) {
+        return (
+            <D2App
+                config={config}
+                resizePluginWidth={resizePluginWidth}
+                {...propsFromParent}
+            />
+        )
+    }
+    return (
+        <PluginResizeInner
+            D2App={D2App}
+            config={config}
+            propsFromParent={propsFromParent}
+            resizePluginHeight={resizePluginHeight}
+            resizePluginWidth={resizePluginWidth}
+        />
     )
 }
 


### PR DESCRIPTION
See https://dhis2.atlassian.net/jira/software/c/projects/LIBS/issues/LIBS-634

This PR updates the styling around a plugin loaded by a shell:

- plugins that have fixed dimensions: app-shell loads the d2 without any divs/resizing logic
- plugins that have at least one dimension that can resize: load with extra wrapper divs and resizing logic.

Previously, plugins without resizing logic "skipped" the resizing logic (e.g. resizing observer not set up), but I kept (for consistency/simplicity) the extra wrapper divs in the expectation that they would not have issues. From a visual perspective, the wrapper divs don't do anything, but they are apparently preventing highcharts charts from executing their own resizing logic when used in dashboards.


Checked with dashboard/data visualizer, and this new implementation seems to resolve issue:
![vis_plugin_highcharts](https://github.com/dhis2/app-platform/assets/18490902/34048bf4-74f8-416b-8f1d-e078760a7f94)