### PR TITLE
fix(alerts): ensure hiding works correctly and alerts are not re-added [DHIS2-15438]

### DIFF
--- a/adapter/src/components/Alerts.js
+++ b/adapter/src/components/Alerts.js
@@ -8,12 +8,12 @@ import React, { useCallback, useState } from 'react'
  * from `@dhis2/ui` should leave the screen with a hide-animation.
  * This works well, for alerts that hide "naturally" (after the
  * timeout expires or when the close icon is clicked). In these
- * cases the componsent will request to be removed from the alerts-
+ * cases the component will request to be removed from the alerts-
  * manager after the animation completes. However, when
  * programatically hiding an alert this is the other way around:
  * the alert is removed from the alerts-manager straight away and
  * if we were to render the alerts from the `useAlerts` hook, these
- * alerts would be removed from the DOM abrubdly without an animation.
+ * alerts would be removed from the DOM abruptly without an animation.
  * To prevent this from happening, we have implemented the
  * `useAlertsWithHideCache` hook:
  *  - It contains all alerts from the alert-manager, with

--- a/adapter/src/components/Alerts.js
+++ b/adapter/src/components/Alerts.js
@@ -1,4 +1,4 @@
-import { useAlerts } from '@dhis2/app-service-alerts'
+import { useAlerts } from '@dhis2/app-runtime'
 import { AlertStack, AlertBar } from '@dhis2/ui'
 import React, { useCallback, useState } from 'react'
 

--- a/adapter/src/components/Alerts.js
+++ b/adapter/src/components/Alerts.js
@@ -1,53 +1,89 @@
-import { useAlerts } from '@dhis2/app-runtime'
-import { AlertBar, AlertStack } from '@dhis2/ui'
-import React, { useState, useEffect } from 'react'
+import { useAlerts } from '@dhis2/app-service-alerts'
+import { AlertStack, AlertBar } from '@dhis2/ui'
+import React, { useCallback, useState } from 'react'
 
-/*
- * The alert-manager which populates the `useAlerts` hook from `@dhis2/app-service-alerts`
- * hook with alerts only supports simply adding and removing alerts. However, the
- * `AlertBar` from `@dhis2/ui` should leave the screen with a hide-animation, so this
- * requires an additional state. The `alertStackAlerts` state in the Alerts component
- * provides this addional state:
- *  - It contains all alerts from the alert-manager, with `options.hidden` set to `false`
- *  - And also alerts which have been removed from the alert-manager, but still have their
- *    leave animation in progress, whtih `options.hidden` set to `true`)
- * Alerts are removed from the `alertStackAlerts` state once the `onHidden` callback fires
- */
+/* The alerts-manager which populates the `useAlerts` hook from
+ * `@dhis2/app-service-alerts` hook with alerts only supports
+ * simply adding and removing alerts. However, the `AlertBar`
+ * from `@dhis2/ui` should leave the screen with a hide-animation.
+ * This works well, for alerts that hide "naturally" (after the
+ * timeout expires or when the close icon is clicked). In these
+ * cases the componsent will request to be removed from the alerts-
+ * manager after the animation completes. However, when
+ * programatically hiding an alert this is the other way around:
+ * the alert is removed from the alerts-manager straight away and
+ * if we were to render the alerts from the `useAlerts` hook, these
+ * alerts would be removed from the DOM abrubdly without an animation.
+ * To prevent this from happening, we have implemented the
+ * `useAlertsWithHideCache` hook:
+ *  - It contains all alerts from the alert-manager, with
+ *    `options.hidden` set to `false`
+ *  - And also alerts which have been removed from the alert-manager,
+ *    but still have their leave animation in progress, with
+ *    `options.hidden` set to `true`
+ *  - Alerts are removed once the `onHidden` callback fires */
+
+const useAlertsWithHideCache = () => {
+    const [alertsMap] = useState(new Map())
+    /* We don't use this state value, it is used to trigger
+     * a rerender to remove the hidden alert from the DOM */
+    const [, setLastRemovedId] = useState(null)
+    const alertManagerAlerts = useAlerts()
+    const updateAlertsFromManager = useCallback(
+        (newAlerts = []) => {
+            const newAlertsIdLookup = new Set()
+            newAlerts.forEach((alert) => {
+                newAlertsIdLookup.add(alert.id)
+                if (!alertsMap.has(alert.id)) {
+                    // new alerts, these are not hiding
+                    alertsMap.set(alert.id, {
+                        ...alert,
+                        options: {
+                            ...alert.options,
+                            hidden: alert.options.hidden || false,
+                        },
+                    })
+                }
+            })
+            // alerts in alertsMap but not in newAlerts are hiding
+            alertsMap.forEach((alert) => {
+                if (!newAlertsIdLookup.has(alert.id)) {
+                    alert.options.hidden = true
+                }
+            })
+        },
+        [alertsMap]
+    )
+    const removeAlert = useCallback(
+        (id) => {
+            alertsMap.delete(id)
+            setLastRemovedId(id)
+        },
+        [alertsMap]
+    )
+
+    updateAlertsFromManager(alertManagerAlerts)
+
+    return {
+        alerts: Array.from(alertsMap.values()).sort((a, b) => a.id - b.id),
+        removeAlert,
+    }
+}
 
 const Alerts = () => {
-    const alertManagerAlerts = useAlerts()
-    const [alertStackAlerts, setAlertStackAlerts] = useState(alertManagerAlerts)
-    const removeAlertStackAlert = (id) =>
-        setAlertStackAlerts(
-            alertStackAlerts.filter(
-                (alertStackAlert) => alertStackAlert.id !== id
-            )
-        )
-
-    useEffect(() => {
-        if (alertManagerAlerts.length > 0) {
-            setAlertStackAlerts((currentAlertStackAlerts) =>
-                mergeAlertStackAlerts(
-                    currentAlertStackAlerts,
-                    alertManagerAlerts
-                )
-            )
-        }
-    }, [alertManagerAlerts])
+    const { alerts, removeAlert } = useAlertsWithHideCache()
 
     return (
         <AlertStack>
-            {alertStackAlerts.map(
+            {alerts.map(
                 ({ message, remove, id, options: { onHidden, ...props } }) => (
                     <AlertBar
                         {...props}
                         key={id}
                         onHidden={() => {
                             onHidden && onHidden()
-                            removeAlertStackAlert(id)
-                            if (alertManagerAlerts.some((a) => a.id === id)) {
-                                remove()
-                            }
+                            removeAlert(id)
+                            remove()
                         }}
                     >
                         {message}
@@ -58,34 +94,4 @@ const Alerts = () => {
     )
 }
 
-function mergeAlertStackAlerts(alertStackAlerts, alertManagerAlerts) {
-    return Object.values({
-        /*
-         * Assume that all alerts in the alertStackAlerts array are hiding.
-         * After the object merge only the alerts not in the alertManagerAlerts
-         * array will have `options.hidden === true`.
-         */
-        ...toIdBasedObjectWithHiddenOption(alertStackAlerts, true),
-        /*
-         * All alertManagerAlerts should be showing. This object merge will
-         * overwrite any alertStackAlert by the alertManagerAlert with
-         * the same `id`, thus ensuring the alert is visible.
-         */
-        ...toIdBasedObjectWithHiddenOption(alertManagerAlerts, false),
-    })
-}
-
-function toIdBasedObjectWithHiddenOption(arr, hidden) {
-    return arr.reduce((obj, item) => {
-        obj[item.id] = {
-            ...item,
-            options: {
-                ...item.options,
-                hidden,
-            },
-        }
-        return obj
-    }, {})
-}
-
-export { Alerts, mergeAlertStackAlerts }
+export { Alerts }

--- a/adapter/src/components/__tests__/Alerts.test.js
+++ b/adapter/src/components/__tests__/Alerts.test.js
@@ -2,7 +2,7 @@ import { useAlert } from '@dhis2/app-runtime'
 import { AlertsProvider } from '@dhis2/app-service-alerts'
 import { act, render, fireEvent, waitFor, screen } from '@testing-library/react'
 import React from 'react'
-import { Alerts, mergeAlertStackAlerts } from '../Alerts.js'
+import { Alerts } from '../Alerts.js'
 
 describe('Alerts', () => {
     beforeEach(() => {
@@ -102,7 +102,10 @@ describe('Alerts', () => {
         // But eventually it is gone
         expect(screen.queryByText(msg)).toBeNull()
     })
-    it.only('removes multiple alerts that hide simultaniously correctly', async () => {
+    it('removes multiple alerts that hide simultaniously correctly', async () => {
+        /* This test case was added to reproduce and fix a bug that
+         * would cause the second alert to be re-added during the
+         * removal of the first alert. */
         const duration = 1000
         const options = { duration }
         const message1 = 'message 1'
@@ -112,13 +115,66 @@ describe('Alerts', () => {
             <Wrapper>
                 <AlertButtons
                     message={message1}
-                    options={options}
                     label={message1}
+                    options={options}
                 />
                 <AlertButtons
                     message={message2}
-                    options={options}
                     label={message2}
+                    options={options}
+                />
+            </Wrapper>
+        )
+
+        act(() => {
+            fireEvent.click(screen.getByText(`Show ${message1}`))
+            /* A small delay between hides is required to reproduce the bug,
+             * because if the hiding is done at the same time, the alerts
+             * would both be removed correctly */
+            jest.advanceTimersByTime(10)
+            fireEvent.click(screen.getByText(`Show ${message2}`))
+        })
+
+        // Both message should show
+        await waitFor(() => screen.getByText(message1))
+        await waitFor(() => screen.getByText(message2))
+        expect(screen.getAllByText(message1)).toHaveLength(1)
+        expect(screen.getAllByText(message2)).toHaveLength(1)
+
+        act(() => {
+            jest.advanceTimersByTime(duration)
+        })
+
+        // Both should still be there while the hide animation runs
+        expect(screen.getAllByText(message1)).toHaveLength(1)
+        expect(screen.getAllByText(message2)).toHaveLength(1)
+
+        act(() => {
+            // Now we advance the time until the hide animation completes
+            jest.advanceTimersByTime(700)
+        })
+
+        /* Now both should be gone. Prior to the bugfix,
+         * the alert with message2 would be showing */
+        expect(screen.queryByText(message1)).toBeNull()
+        expect(screen.queryByText(message2)).toBeNull()
+    })
+    it('keeps alerts that have been removed programatically around until the animation is done', async () => {
+        const options = { permanent: true }
+        const message1 = 'message 1'
+        const message2 = 'message 2'
+
+        render(
+            <Wrapper>
+                <AlertButtons
+                    message={message1}
+                    label={message1}
+                    options={options}
+                />
+                <AlertButtons
+                    message={message2}
+                    label={message2}
+                    options={options}
                 />
             </Wrapper>
         )
@@ -135,152 +191,39 @@ describe('Alerts', () => {
         expect(screen.getAllByText(message2)).toHaveLength(1)
 
         act(() => {
-            /* The time is advanced by the following value:
-             * show+duration + hide-animation-duration + show-animation-duration
-             * This is to reproduce a bug that would cause the first alert to be
-             * re-added during the removal of the second alert */
-            jest.advanceTimersByTime(duration + 200)
+            fireEvent.click(screen.getByText(`Hide ${message1}`))
+            jest.advanceTimersByTime(50)
         })
 
-        /* Now both should be gone. Prior to the bugfix,
-         * the alert with message1 would be showing */
+        // Both should still be there while the hide animation runs
+        expect(screen.getAllByText(message1)).toHaveLength(1)
+        expect(screen.getAllByText(message2)).toHaveLength(1)
+
+        act(() => {
+            // Now we advance the time until the hide animation completes
+            jest.advanceTimersByTime(1000)
+        })
+
+        // The alert that was hidden should now be gone
+        expect(screen.queryByText(message1)).toBeNull()
+        expect(screen.getAllByText(message2)).toHaveLength(1)
+
+        act(() => {
+            fireEvent.click(screen.getByText(`Hide ${message2}`))
+            jest.advanceTimersByTime(50)
+        })
+
+        // The second alert should still be there while its hide animation runs
+        expect(screen.queryByText(message1)).toBeNull()
+        expect(screen.getAllByText(message2)).toHaveLength(1)
+
+        act(() => {
+            fireEvent.click(screen.getByText(`Hide ${message2}`))
+            jest.advanceTimersByTime(700)
+        })
+
+        // Now both should be gone
         expect(screen.queryByText(message1)).toBeNull()
         expect(screen.queryByText(message2)).toBeNull()
-    })
-})
-
-describe('mergeAlertStackAlerts', () => {
-    it('add alerts from the alert manager and adds `hidden: false` to the options', () => {
-        const alertStackAlerts = []
-        const alertManagerAlerts = [
-            {
-                id: 1,
-                message: 'test1',
-                options: { permanent: true },
-            },
-            {
-                id: 2,
-                message: 'test2',
-                options: { permanent: true },
-            },
-        ]
-        expect(
-            mergeAlertStackAlerts(alertStackAlerts, alertManagerAlerts)
-        ).toEqual([
-            {
-                id: 1,
-                message: 'test1',
-                options: { hidden: false, permanent: true },
-            },
-            {
-                id: 2,
-                message: 'test2',
-                options: { hidden: false, permanent: true },
-            },
-        ])
-    })
-    it('keeps alerts unchanged if the alert-manager and alert-stack contain equivalent items', () => {
-        const alertStackAlerts = [
-            {
-                id: 1,
-                message: 'test1',
-                options: { permanent: true, hidden: false },
-            },
-            {
-                id: 2,
-                message: 'test2',
-                options: { permanent: true, hidden: false },
-            },
-        ]
-        const alertManagerAlerts = [
-            {
-                id: 1,
-                message: 'test1',
-                options: { permanent: true },
-            },
-            {
-                id: 2,
-                message: 'test2',
-                options: { permanent: true },
-            },
-        ]
-        expect(
-            mergeAlertStackAlerts(alertStackAlerts, alertManagerAlerts)
-        ).toEqual(alertStackAlerts)
-    })
-    it('keeps alerts in the alert-stack and sets `hidden` to `true` if they are no longer in the alert-manager', () => {
-        const alertStackAlerts = [
-            {
-                id: 1,
-                message: 'test1',
-                options: { permanent: true, hidden: false },
-            },
-            {
-                id: 2,
-                message: 'test2',
-                options: { permanent: true, hidden: false },
-            },
-        ]
-        const alertManagerAlerts = [
-            {
-                id: 2,
-                message: 'test2',
-                options: { permanent: true },
-            },
-        ]
-        expect(
-            mergeAlertStackAlerts(alertStackAlerts, alertManagerAlerts)
-        ).toEqual([
-            {
-                id: 1,
-                message: 'test1',
-                options: { permanent: true, hidden: true },
-            },
-            {
-                id: 2,
-                message: 'test2',
-                options: { permanent: true, hidden: false },
-            },
-        ])
-    })
-    it('updates alerts in the alert-stack with the properties of the alerts in the alert-manager', () => {
-        const alertStackAlerts = [
-            {
-                id: 1,
-                message: 'test1',
-                options: { permanent: true, hidden: false },
-            },
-            {
-                id: 2,
-                message: 'test2',
-                options: { permanent: true, hidden: false },
-            },
-        ]
-        const alertManagerAlerts = [
-            {
-                id: 1,
-                message: 'test1 EDITED',
-                options: { success: true },
-            },
-            {
-                id: 2,
-                message: 'test2 EDITED',
-                options: { success: true },
-            },
-        ]
-        expect(
-            mergeAlertStackAlerts(alertStackAlerts, alertManagerAlerts)
-        ).toEqual([
-            {
-                id: 1,
-                message: 'test1 EDITED',
-                options: { success: true, hidden: false },
-            },
-            {
-                id: 2,
-                message: 'test2 EDITED',
-                options: { success: true, hidden: false },
-            },
-        ])
     })
 })


### PR DESCRIPTION
This PR fixes a bug that was observed in the maps-app where multiple info alerts were added at approximately the same time. These alerts would then also hide at approximately the same time, but one alert would finish first and this would cause the other one to remount and restart its appear/show/hide lifecycle.

It took a long time to debug this issue and I found a few things wrong:
- It turned out that on occasion the `alertStackAlerts` was an empty array when it should have been populated. In the next render cycle, the array would have the expected alerts again, but because the array was empty during the previous render cycle, everything was remounting all the time.
- The fact that both the alerts-array from the alerts-manager and the local alerts array were stateful/reactive and because the latter was updated in response to changes in the former, was causing a double render all the time. This was making the problem a lot more difficult to reason about, and also wasteful. The new hook doesn't have a local reactive state for the alerts, it will only trigger a single re-render when the alerts from the alerts-manager change, or when one of the alerts is done hiding.

After fixing that empty-array and double render problem I realised I had broken some preexisting functionality: As I [explain here](https://github.com/dhis2/app-platform/blob/5c11c9fe088274d043255c4f25f597ddf293d557/adapter/src/components/Alerts.js#L5-L24), there is a fundamental difference between how alerts hide "naturally" VS programatically. I had already catered for this in the original implementation, but broke that while fixing the initial bug. I found this problem by chance: there were no test cases that broke. So I decided to add a test for this as well.