### PR TITLE
fix: plugin boundary retry if plugin logic is skipped [LIBS-633]

### DIFF
--- a/adapter/src/components/AppWrapper.js
+++ b/adapter/src/components/AppWrapper.js
@@ -32,7 +32,9 @@ const AppWrapper = ({
                         plugin={true}
                         onPluginError={onPluginError}
                         onRetry={() => {
-                            clearPluginError()
+                            if (clearPluginError) {
+                                clearPluginError()
+                            }
                             window.location.reload()
                         }}
                     >


### PR DESCRIPTION
Part of [LIBS-633](https://dhis2.atlassian.net/browse/LIBS-633)

I noticed a small bug: when clicking on the "Retry" button in the plugin error boundary in the App Wrapper, if `skipPluginLogic` is set in `d2.config.js`, the action can fail with the error `clearPluginError is not a function` -- here's a fix by checking if that prop exists before executing

Before:

https://github.com/dhis2/app-platform/assets/49666798/03c2bbd4-af6c-4041-948f-e89dba1ab6a7



After:


https://github.com/dhis2/app-platform/assets/49666798/98608db2-e3b5-49a3-898b-e8ec869d18af



[LIBS-633]: https://dhis2.atlassian.net/browse/LIBS-633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ