### PR TITLE
chore: set dir to auto for new apps [LIBS-645]

### DIFF
--- a/cli/config/d2.config.app.js
+++ b/cli/config/d2.config.app.js
@@ -4,6 +4,7 @@ const config = {
     entryPoints: {
         app: './src/App.js',
     },
+    dir: 'auto',
 }
 
 module.exports = config


### PR DESCRIPTION
See https://dhis2.atlassian.net/jira/software/c/projects/LIBS/issues/LIBS-645

This PR updates the configuration for newly initialized app to set `dir: 'auto'` so that by default apps will follow direction of user language, and hence display 'rtl' for Arabic, Urdu, etc.,

(After this is merged, https://github.com/dhis2/cli dependencies need to be updated)