### PR TITLE
feat(init): set direction: 'auto' and import locales for new apps [LIBS-645]

### DIFF
--- a/cli/config/d2ConfigDefaults.js
+++ b/cli/config/d2ConfigDefaults.js
@@ -1,3 +1,11 @@
+/**
+ * Note that these values are different from the boilerplate files that
+ * are copied when using `d2-app-scripts init` -- these are used as defaults
+ * when parsing d2 config of existing apps
+ *
+ * The boilerplate files live in /config/init/
+ */
+
 const defaultsApp = {
     type: 'app',
 

--- a/cli/config/init/d2.config.app.js
+++ b/cli/config/init/d2.config.app.js
@@ -4,6 +4,8 @@ const config = {
     entryPoints: {
         app: './src/App.jsx',
     },
+
+    direction: 'auto',
 }
 
 module.exports = config

--- a/cli/config/init/entrypoint.jsx
+++ b/cli/config/init/entrypoint.jsx
@@ -2,6 +2,8 @@ import { useDataQuery } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import React from 'react'
 import classes from './App.module.css'
+// './locales' will be populated after running start or build scripts
+import './locales'
 
 const query = {
     me: {


### PR DESCRIPTION
[LIBS-645](https://dhis2.atlassian.net/browse/LIBS-645)

Can be tested by checking out the branch and running `yarn d2-app-scripts init new-app` (note that the new app will use the version of `cli-app-scripts` on master): `direction: 'auto'` should be in `d2.config.js`, and setting an RTL language should display RTL direction (in the HTML, and the app text should look like "!Welcome to DHIS2")

The separation between boilerplate and config defaults can also be tested by commenting out `direction: 'auto'` in the config -- the current `direction: 'ltr'` default behavior should be restored

I think the version _after_ the Vite migration would be a good time to update the default direction to 'auto' to try to avoid _too_ many breaking changes with the migration

I also added the locale import to the entrypoint file, since that's a common oversight

[LIBS-645]: https://dhis2.atlassian.net/browse/LIBS-645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ