### PR TITLE
feat: hmr for .js files; fix file server for fonts [LIBS-635]

### DIFF
--- a/cli/config/makeViteConfig.mjs
+++ b/cli/config/makeViteConfig.mjs
@@ -162,7 +162,11 @@ export default ({ paths, config, env, host }) => {
              * inline `webpackChunkName` usage. Third-party plugin.
              */
             dynamicImport(),
-            react({ babel: { plugins: ['styled-jsx/babel'] } }),
+            react({
+                babel: { plugins: ['styled-jsx/babel'] },
+                // Enables HMR for .js files:
+                jsxRuntime: 'classic',
+            }),
         ],
 
         // Allow JSX in .js pt. 2

--- a/cli/config/makeViteConfig.mjs
+++ b/cli/config/makeViteConfig.mjs
@@ -1,5 +1,9 @@
 import react from '@vitejs/plugin-react'
-import { defineConfig, transformWithEsbuild } from 'vite'
+import {
+    defineConfig,
+    searchForWorkspaceRoot,
+    transformWithEsbuild,
+} from 'vite'
 import dynamicImport from 'vite-plugin-dynamic-import'
 
 // This file is used to create config to use with the Vite Node API
@@ -125,7 +129,17 @@ export default ({ paths, config, env, host }) => {
         // Static replacement of vars at build time
         define: getDefineOptions(env),
 
-        server: { host },
+        server: {
+            host,
+            // By default, Vite allows serving files from a workspace root or
+            // falls back to the app root. Since we run the app in .d2/shell/,
+            // if the app is not in a workspace, files in cwd/node_modules can
+            // be out of reach (like fonts, which don't get bundled).
+            // Start the workspace search from cwd so it falls back to that
+            // when not in a workspace; then fonts in node_modules are usable
+            // https://vitejs.dev/config/server-options.html#server-fs-allow
+            fs: { allow: [searchForWorkspaceRoot(process.cwd())] },
+        },
 
         build: {
             outDir: 'build',


### PR DESCRIPTION
[LIBS-635](https://dhis2.atlassian.net/browse/LIBS-635)

### Fonts:

Previously, apps were encountering this error:
```
The request url "/Users/kai/dev/dhis2/scheduler-app/node_modules/typeface-roboto/files/roboto-latin-500.woff2" is outside of Vite serving allow list.

- /Users/kai/dev/dhis2/scheduler-app/.d2/shell
- /Users/kai/dev/dhis2/scheduler-app/node_modules/vite/dist/client

Refer to docs https://vitejs.dev/config/server-options.html#server-fs-allow for configurations and more details.

The request url "/Users/kai/dev/dhis2/scheduler-app/node_modules/typeface-roboto/files/roboto-latin-700.woff2" is outside of Vite serving allow list.
The request url "/Users/kai/dev/dhis2/scheduler-app/node_modules/typeface-roboto/files/roboto-latin-400.woff2" is outside of Vite serving allow list.
```

As mentioned in the docs linked in the error, the server allow list starts by looking for a workspace from the _app_ root, and if none is found, falls back to the app root. Since the app root is in `.d2/shell/`, that excludes `./node_modules`, and fonts have trouble getting served. JS from node_modules is probably bundled by esbuild and doesn't have the same problem.

This is fixed by running the `searchForWorkspaceRoot()` logic for `fs.allow` from `process.cwd()`, instead of from the app root (the default behavior); then, if a workspace isn't found, it'll fall back to `cwd` instead of the app root in `.d2/shell/`, and `node_modules` will be accessible

### HMR in JS:

I finally [found](https://github.com/vitejs/vite/discussions/3448#discussioncomment-6704859) the config setting to enable HMR on JS files with JSX in them 🙃 

This makes support for JS very good, and migrating to JSX is actually not _strictly_ necessary... that said, it's still probably good to do, 1) for best practices, 2) to improve Vite performance, and 3) to substantially reduce confusing config

I've actually been thinking about this kind of mode of support for JSX-in-JS-files:
1. By default, `yarn start` and `build` don't support it. Ideally, if it crashes due to JSX-in-JS, the script will point to a migration script or the bypass flag
2. The user can use an option, either a `--allowJsxInJs` CLI flag or an `ALLOW_JSX_IN_JS` env var, to allow it -- in this case, the relevant config will be added 
3. In the next major version, the `--allowJsxInJs` option will be removed

I'm curious about thoughts on that! ☝️ 

[LIBS-635]: https://dhis2.atlassian.net/browse/LIBS-635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ