### PR TITLE
fix: jsx in js support [LIBS-633]

### DIFF
--- a/cli/config/makeViteConfig.mjs
+++ b/cli/config/makeViteConfig.mjs
@@ -1,6 +1,7 @@
 import react from '@vitejs/plugin-react'
 import {
     defineConfig,
+    mergeConfig,
     searchForWorkspaceRoot,
     transformWithEsbuild,
 } from 'vite'
@@ -17,28 +18,33 @@ import dynamicImport from 'vite-plugin-dynamic-import'
  * Vite normally throws an error when JSX syntax is used in a file without a
  * .jsx or .tsx extension. This is by design, in order to improve transform
  * performance by not parsing JS files for JSX.
- * This plugin is 1 of 2 config options that allow JSX to be used in
- * .js or .ts files -- the options in `optimizeDeps` below are part 2.
+ * 
+ * This plugin and the `optimizeDeps` options in this config object,
+ * along with the `jsxRuntime: 'classic'` option in the React plugin of the main
+ * config, can enable support for JSX in .js files. This config object is
+ * merged with the main config if the `--allowJsxInJs` flag is passed
+ * to the CLI
  *
- * NB: State-preserving HMR will not work on React components unless they have
- * a .jsx or .tsx extension though, unfortunately
- *
- * todo: deprecate -- this and optimize deps below have a performance cost
- * on startup
+ * todo: deprecate -- this config has a performance cost, especially on startup
  */
-const jsxInJSPlugin = {
-    name: 'treat-js-files-as-jsx',
-    async transform(code, id) {
-        if (!id.match(/src\/.*\.js$/)) {
-            return null
-        }
-        // todo: consider JSX warning if </ or />
-        // Use the exposed transform from vite, instead of directly
-        // transforming with esbuild
-        return transformWithEsbuild(code, id, {
-            loader: 'jsx',
-            jsx: 'automatic',
-        })
+const jsxInJsConfig = {
+    plugins: [{
+        name: 'treat-js-files-as-jsx',
+        async transform(code, id) {
+            if (!id.match(/src\/.*\.js$/)) {
+                return null
+            }
+            // Use the exposed transform from vite, instead of directly
+            // transforming with esbuild
+            return transformWithEsbuild(code, id, {
+                loader: 'jsx',
+                jsx: 'automatic',
+            })
+        },
+    }],
+    optimizeDeps: {
+        force: true,
+        esbuildOptions: { loader: { '.js': 'jsx' } },
     },
 }
 
@@ -108,8 +114,8 @@ const getBuildInputs = (config, paths) => {
 }
 
 // https://vitejs.dev/config/
-export default ({ paths, config, env, host }) => {
-    return defineConfig({
+export default ({ paths, config, env, host, force, allowJsxInJs }) => {
+    const baseConfig = defineConfig({
         // Need to specify the location of the app root, since we're not using
         // the Vite CLI from the app root
         root: paths.shell,
@@ -153,8 +159,6 @@ export default ({ paths, config, env, host }) => {
         },
 
         plugins: [
-            // Allow JSX in .js files pt. 1
-            jsxInJSPlugin,
             /**
              * Allows the dynamic import of `moment/dist/locale/${locale}`
              * in /adapter/src/utils/localeUtils.js.
@@ -164,16 +168,15 @@ export default ({ paths, config, env, host }) => {
             dynamicImport(),
             react({
                 babel: { plugins: ['styled-jsx/babel'] },
-                // Enables HMR for .js files:
-                jsxRuntime: 'classic',
+                // todo: deprecate with other jsx-in-js config
+                // This option allows HMR of JSX-in-JS files, 
+                // but it isn't possible to add with merge config:
+                jsxRuntime: allowJsxInJs ? 'classic' : 'automatic',
             }),
         ],
 
-        // Allow JSX in .js pt. 2
-        // todo: deprecate - has a performance cost on startup
-        optimizeDeps: {
-            force: true,
-            esbuildOptions: { loader: { '.js': 'jsx' } },
-        },
+        optimizeDeps: { force },
     })
+
+    return allowJsxInJs ? mergeConfig(baseConfig, jsxInJsConfig) : baseConfig
 }

--- a/cli/src/commands/build.js
+++ b/cli/src/commands/build.js
@@ -57,6 +57,7 @@ const handler = async ({
     verify,
     force,
     pack: packAppOutput,
+    allowJsxInJs,
 }) => {
     const paths = makePaths(cwd)
 
@@ -139,6 +140,7 @@ const handler = async ({
                     paths,
                     config,
                     env: shell.env,
+                    allowJsxInJs,
                 })
                 await build(viteConfig)
 
@@ -237,6 +239,11 @@ const command = {
             description:
                 'Build in standalone mode (overrides the d2.config.js setting)',
             default: undefined,
+        },
+        allowJsxInJs: {
+            type: 'boolean',
+            description:
+                'Add Vite config to handle JSX in .js files. DEPRECATED: Will be removed in @dhis2/cli-app-scripts v13. Consider using the migration script `d2-app-scripts migrate js-to-jsx` to avoid needing this option',
         },
     },
     handler,

--- a/cli/src/commands/start.js
+++ b/cli/src/commands/start.js
@@ -23,6 +23,7 @@ const handler = async ({
     proxy,
     proxyPort,
     host,
+    allowJsxInJs,
 }) => {
     const paths = makePaths(cwd)
 
@@ -135,6 +136,8 @@ const handler = async ({
                 paths,
                 env: shell.env,
                 host,
+                force,
+                allowJsxInJs,
             })
             const server = await createServer(viteConfig)
 
@@ -180,7 +183,7 @@ const command = {
         force: {
             type: 'boolean',
             description:
-                'Force updating the app shell. Normally, this is only done when a new version of @dhis2/cli-app-scripts is detected',
+                'Force updating the app shell; normally, this is only done when a new version of @dhis2/cli-app-scripts is detected. Also passes the --force option to the Vite server to reoptimize dependencies',
         },
         port: {
             alias: 'p',
@@ -202,6 +205,11 @@ const command = {
             type: 'boolean|string',
             description:
                 'Exposes the server on the local network. Can optionally provide an address to use. [boolean or string]',
+        },
+        allowJsxInJs: {
+            type: 'boolean',
+            description:
+                'Add Vite config to handle JSX in .js files. DEPRECATED: Will be removed in @dhis2/cli-app-scripts v13. Consider using the migration script `d2-app-scripts migrate js-to-jsx` to avoid needing this option',
         },
     },
     handler,

--- a/docs/scripts/build.md
+++ b/docs/scripts/build.md
@@ -25,4 +25,8 @@ Options:
   --watch       Watch source files for changes        [boolean] [default: false]
   --standalone  Build in standalone mode (overrides the d2.config.js setting)
                                                                        [boolean]
+  --allowJsxInJs  Add Vite config to handle JSX in .js files. DEPRECATED: Will
+                  be removed in @dhis2/cli-app-scripts v13. Consider using the
+                  migration script `d2-app-scripts migrate js-to-jsx` to avoid
+                  needing this option                                  [boolean]
 ```

--- a/docs/scripts/start.md
+++ b/docs/scripts/start.md
@@ -19,13 +19,19 @@ Global Options:
   --config       Path to JSON config file
 
 Options:
-  --cwd        working directory to use (defaults to cwd)
-  --force      Force updating the app shell. Normally, this is only done when a
-               new version of @dhis2/cli-app-scripts is detected       [boolean]
-  --port, -p   The port to use when running the development server
+  --cwd           working directory to use (defaults to cwd)
+  --force         Force updating the app shell; normally, this is only done when
+                  a new version of @dhis2/cli-app-scripts is detected. Also
+                  passes the --force option to the Vite server to reoptimize
+                  dependencies                                         [boolean]
+  --port, -p      The port to use when running the development server
                                                         [number] [default: 3000]
-  --proxy, -P  The remote DHIS2 instance the proxy should point to      [string]
-  --proxyPort  The port to use when running the proxy   [number] [default: 8080]
-  --host       Exposes the server on the local network. Can optionally provide
-               an address to use. [boolean or string]
+  --proxy, -P     The remote DHIS2 instance the proxy should point to   [string]
+  --proxyPort     The port to use when running the proxy[number] [default: 8080]
+  --host          Exposes the server on the local network. Can optionally
+                  provide an address to use. [boolean or string]
+  --allowJsxInJs  Add Vite config to handle JSX in .js files. DEPRECATED: Will
+                  be removed in @dhis2/cli-app-scripts v13. Consider using the
+                  migration script `d2-app-scripts migrate js-to-jsx` to avoid
+                  needing this option                                  [boolean]
 ```

--- a/docs/scripts/start.md
+++ b/docs/scripts/start.md
@@ -22,7 +22,7 @@ Options:
   --cwd           working directory to use (defaults to cwd)
   --force         Force updating the app shell; normally, this is only done when
                   a new version of @dhis2/cli-app-scripts is detected. Also
-                  passes the --force option to the Vite server to reoptimize
+                  passes the --force option to the Vite server to re-optimize
                   dependencies                                         [boolean]
   --port, -p      The port to use when running the development server
                                                         [number] [default: 3000]


### PR DESCRIPTION
Pretty much described by: [LIBS-633](https://dhis2.atlassian.net/browse/LIBS-663)

Suggested testing:
1. In `/examples/simple-app`, rename `Alerter.jsx` to `Alerter.js`, and update the import in `App.jsx`
5. Try running the start and build scripts with and without `--allowJsxInJs`
6. Also try it with `Alerter.jsx` as-is, with its original filename

As far as logging a clarifying message to a user that stumbles into the "no JSX in JS" error, i.e. to point them to the migration script or the workaround flag, I didn't yet figure out a good way to catch that error that the Vite server throws... there may be something available in these APIs though:
* [Vite dev server](https://vitejs.dev/guide/api-javascript#vitedevserver), which has a Node HTTP server and Connect middlewares instance
    * [Node HTTP server](https://nodejs.org/api/http.html#class-httpserver)
    * [Connect middlewares](https://github.com/senchalabs/connect#use-middleware)

I also made the decision to have the `--force` flag as apply the same flag to the Vite server, which triggers re-optimization of dependencies -- i.e., crawling node_modules and bundling up relevant files. This is a useful tool for a developer who is making modifications to files inside node_modules, and wants to the see the changes reflected in a running app -- the workflow looks like this:
1. Start an app with `yarn start --force` (you'll see `Forced re-optimization of dependencies` printed in the console)
2. Make desired changes to `node_modules`
3. Restart the Vite server by typing `r + Enter` in the console (this is basically instant; much faster than stopping the script and running `yarn start` again)
4. Dependencies will be re-optimized again, and changes should be visible in the running app

