### PR TITLE
feat: auto redirect to safe mode on login app error [LIBS-670]

### DIFF
--- a/adapter/i18n/en.pot
+++ b/adapter/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-06-21T08:27:55.991Z\n"
-"PO-Revision-Date: 2024-06-21T08:27:55.991Z\n"
+"POT-Creation-Date: 2024-08-28T09:08:40.219Z\n"
+"PO-Revision-Date: 2024-08-28T09:08:40.219Z\n"
 
 msgid "Save your data"
 msgstr "Save your data"
@@ -50,9 +50,6 @@ msgstr "Try again"
 
 msgid "Something went wrong"
 msgstr "Something went wrong"
-
-msgid "Redirect to safe login mode"
-msgstr "Redirect to safe login mode"
 
 msgid "Hide technical details"
 msgstr "Hide technical details"

--- a/adapter/src/components/ErrorBoundary.js
+++ b/adapter/src/components/ErrorBoundary.js
@@ -59,6 +59,9 @@ export class ErrorBoundary extends Component {
                 this.props.onPluginError(error)
             }
         }
+        if (this.props.loginApp) {
+            console.error(error)
+        }
         this.setState({
             error,
             errorInfo,
@@ -96,6 +99,10 @@ export class ErrorBoundary extends Component {
         const { children, fullscreen, onRetry, loginApp, baseURL } = this.props
 
         if (this.state.error) {
+            if (loginApp && baseURL) {
+                this.handleSafeLoginRedirect()
+            }
+
             if (this.props.plugin) {
                 return (
                     <>
@@ -136,15 +143,6 @@ export class ErrorBoundary extends Component {
                         <h1 className="message">
                             {i18n.t('Something went wrong')}
                         </h1>
-                        {loginApp && baseURL && (
-                            <div className="retry">
-                                <UIButton
-                                    onClick={this.handleSafeLoginRedirect}
-                                >
-                                    {i18n.t('Redirect to safe login mode')}
-                                </UIButton>
-                            </div>
-                        )}
                         {onRetry && (
                             <div className="retry">
                                 <UIButton onClick={onRetry}>


### PR DESCRIPTION
**DRAFT**

_Might be good to decide if we want to implement safe login mode in v42, before proceeding with an auto redirect as now the app on error (in v42) will redirect to a non-existent page. Also, might be good to think about what safe login mode should look like as an autoredirect will now bring users to a login page that looks different than the actual login page (which I imagine could make people suspicious of the content)_

See https://dhis2.atlassian.net/jira/software/c/projects/LIBS/issues/LIBS-670

This PR:
- updates error boundary in adapter to auto redirect to safe login mode for login app
- outputs error to console by default for login app (if you enable persistence of console logs on navigation, you would see the console error after redirect)