### PR TITLE
fix: provide fallback api version [LIBS-683]

### DIFF
--- a/.github/workflows/dhis2-verify-lib.yml
+++ b/.github/workflows/dhis2-verify-lib.yml
@@ -61,7 +61,7 @@ jobs:
               with:
                   node-version: 14.x
 
-            - uses: actions/download-artifact@v2
+            - uses: actions/download-artifact@v4
               with:
                   name: lib-build
 
@@ -83,7 +83,7 @@ jobs:
               with:
                   node-version: 14.x
 
-            - uses: actions/download-artifact@v2
+            - uses: actions/download-artifact@v4
               with:
                   name: lib-build
 

--- a/.github/workflows/dhis2-verify-lib.yml
+++ b/.github/workflows/dhis2-verify-lib.yml
@@ -29,7 +29,7 @@ jobs:
             - name: Build
               run: yarn build
 
-            - uses: actions/upload-artifact@v2
+            - uses: actions/upload-artifact@v4
               with:
                   name: lib-build
                   path: |

--- a/adapter/src/components/ServerVersionProvider.js
+++ b/adapter/src/components/ServerVersionProvider.js
@@ -113,7 +113,9 @@ export const ServerVersionProvider = ({
                     setSystemInfoState({
                         loading: false,
                         error: undefined,
-                        systemInfo: { version: loginConfig.apiVersion },
+                        systemInfo: {
+                            version: loginConfig.apiVersion ?? '2.41',
+                        },
                     })
                 })
                 .catch((e) => {


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/LIBS-683

This provides a safeguard for the login app to default to an api version if the api version is missing from api/loginConfig (see linked slack discussion on the thread).

I think it would be better to fix this on the backend to reliably be able to get and return that api version, but this helps prevent users not being able to log in while we refine how to improve consistency of api/loginConfig.