### PR TITLE
fix: add @babel/plugin-syntax-dynamic-import as a direct dependency

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -25,6 +25,7 @@
         "@babel/plugin-proposal-class-properties": "^7.8.3",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
         "@babel/plugin-proposal-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/preset-env": "^7.14.7",
         "@babel/preset-react": "^7.0.0",
         "@babel/preset-typescript": "^7.6.0",


### PR DESCRIPTION
since it is no longer a transitive dependency of babel-preset after these changes in [@babel/preset-env@7.25](https://github.com/babel/babel/pull/16824) 