### PR TITLE
fix(publishVersion): fix maxBodyLength when uploading to appHub

### DIFF
--- a/cli/src/lib/publishVersion.js
+++ b/cli/src/lib/publishVersion.js
@@ -60,15 +60,16 @@ module.exports = async ({
         await client.post(uploadAppUrl, formData, {
             headers: formData.getHeaders(),
             timeout: timeout * 1000,
+            maxBodyLength: Infinity,
+            maxContentLength: Infinity,
         })
 
         reporter.info(`Successfully published ${name} with version ${version}`)
     } catch (e) {
         if (e.isAxiosError) {
             dumpHttpError('Failed to upload app, HTTP error', e.response)
-        } else {
-            reporter.error(e)
         }
+        reporter.error(e)
         exit(1)
     }
 }


### PR DESCRIPTION
### Background

The `maps-app` failed to uploading using `d2-app-scripts publish`. See eg. this run: https://github.com/dhis2/maps-app/actions/runs/11663969768/job/32473530177 . 
The truncated error made this quite hard to debug - I had to locally run this with a change in `node_modules` of the platform to see the actual error. So I made it dump the error regardless if it's axios-error.
The reason it failed was due to `axios`-defaults for `maxBodyLength`, which appears to be `10MB`. However the server should enforce the length, not the client. The server already does this and is currently configured to allow up to `20MB` (ref: https://github.com/dhis2/app-hub/blob/master/server/src/routes/v1/apps/handlers/createAppVersion.js#L36 )

## Implementation

Adds `maxContentLength: infinity; maxBodyLength: infinity` to hopefully fix this issue. 