### PR TITLE
docs(v12-migration): fix title and link

### DIFF
--- a/docs/migration/v12.md
+++ b/docs/migration/v12.md
@@ -1,10 +1,10 @@
 ---
-title: v12: Migrate to Vite & React 18
+title: "v12: Migrate to Vite & React 18"
 ---
 
 # Platform v12 Migration Guide: Vite & React 18
 
-Version 12.0.0 introduces Vite and React 18 to the platform, and introduces some great benefits including faster dev server startup, faster application builds, and better plugin UX. Check out the announcement blog post here (todo: link)!
+Version 12.0.0 introduces Vite and React 18 to the platform, and introduces some great benefits including faster dev server startup, faster application builds, and better plugin UX. Check out the announcement blog post [here](/blog/2024/12/app-platform-v12)!
 
 This guide describes the features that version 12 introduces, then some tips on how to easily upgrade to `@dhis2/cli-app-scripts` v12 and what to expect along the way.
 

--- a/docs/migration/v12.md
+++ b/docs/migration/v12.md
@@ -1,5 +1,5 @@
 ---
-title: "v12: Migrate to Vite & React 18"
+title: 'v12: Migrate to Vite & React 18'
 ---
 
 # Platform v12 Migration Guide: Vite & React 18


### PR DESCRIPTION
Quotes are needed around the title to allow the `:` character, and added a link -- tested locally in the dev portal:

https://github.com/user-attachments/assets/bbfebafd-51a1-455f-b8f8-472ee98666c7

