### PR TITLE
feat: update jest.mock imports with migrate js-to-jsx script

### DIFF
--- a/cli/src/commands/migrate/js-to-jsx.js
+++ b/cli/src/commands/migrate/js-to-jsx.js
@@ -79,6 +79,11 @@ const resolveImportSource = ({
     return isRenamed ? importSourceWithExtension + 'x' : importSource
 }
 
+const isJestMock = (callee) =>
+    callee.type === 'MemberExpression' &&
+    callee.object?.name === 'jest' &&
+    callee.property?.name === 'mock'
+
 const updateImports = async ({
     filepath,
     renamedFiles,

--- a/cli/src/commands/migrate/js-to-jsx.js
+++ b/cli/src/commands/migrate/js-to-jsx.js
@@ -132,6 +132,45 @@ const updateImports = async ({
                     contentUpdated = true
                 }
             },
+            // Triggers on function calls -- we're looking for `jest.mock()`
+            CallExpression: (astPath) => {
+                const { callee } = astPath.node
+                if (!isJestMock(callee)) {
+                    return
+                }
+
+                const mockFileSource = astPath.node.arguments[0].value
+                if (!mockFileSource.startsWith('.')) {
+                    return // It's not a relative import; skip this one
+                }
+
+                const newMockFileSource = resolveImportSource({
+                    filepath,
+                    importSource: mockFileSource,
+                    renamedFiles,
+                    skipUpdatingImportsWithoutExtension,
+                })
+
+                // Since generating code from babel doesn't respect formatting,
+                // update imports with just string replacement
+                if (newMockFileSource !== mockFileSource) {
+                    // updating & replacing the raw value, which includes quotes,
+                    // ends up being more precise and avoids side effects
+                    const rawImportSource = astPath.node.arguments[0].extra.raw
+                    const newRawImportSource = rawImportSource.replace(
+                        mockFileSource,
+                        newMockFileSource
+                    )
+                    reporter.debug(
+                        `    Replacing ${mockFileSource} => ${newMockFileSource}`
+                    )
+                    newCode = newCode.replace(
+                        rawImportSource,
+                        newRawImportSource
+                    )
+                    contentUpdated = true
+                }
+            },
         })
 
         if (contentUpdated) {


### PR DESCRIPTION
[LIBS-739](https://dhis2.atlassian.net/browse/LIBS-739)

Pretty similar logic to the other import replacer -- I used [AST explorer](https://astexplorer.net/) to help figure out the right nodes

This can be tested by running `../app-platform/cli/bin/d2-app-scripts migrate js-to-jsx` (and optionally `--debug`) in an app like Dashboard, if it's in a directory neighboring `app-platform`; then run `yarn test` to make sure the tests work. You can also inspect the mock imports; `src/components/__tests__/App.spec.js(x)` has several components imported:

<img width="1840" alt="Screenshot 2025-01-24 at 18 44 13" src="https://github.com/user-attachments/assets/42e24920-992c-401d-8476-e5df38184a82" />



[LIBS-739]: https://dhis2.atlassian.net/browse/LIBS-739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ