### PR TITLE
feat(vite): add source maps to build

### DIFF
--- a/cli/config/makeViteConfig.mjs
+++ b/cli/config/makeViteConfig.mjs
@@ -159,6 +159,7 @@ export default ({ paths, config, env, host, force, allowJsxInJs }) => {
 
         build: {
             outDir: 'build',
+            sourcemap: true,
             rollupOptions: {
                 input: getBuildInputs(config, paths),
                 output: {


### PR DESCRIPTION
This may be an expected default, but also makes it possible to use [Teamscale](https://docs.teamscale.com/howto/setting-up-profiler-tga/javascript/) to collect test coverage of Vite apps easily using a standalone build

(CRA added source maps by default)