### PR TITLE
fix: surface error when 'd2-app-scripts test' fails

### DIFF
--- a/cli/src/commands/test.js
+++ b/cli/src/commands/test.js
@@ -78,8 +78,10 @@ const handler = async ({
         },
         {
             name: 'test',
-            onError: () =>
-                reporter.error('Test script exited with non-zero exit code'),
+            onError: (e) => {
+                reporter.error(e)
+                reporter.error('Test script exited with non-zero exit code')
+            },
         }
     )
 }


### PR DESCRIPTION
This surfaces the error that happens when running `yarn test`, otherwise the error is swallowed and we just get an unhelpful generic error message.

| Before | After |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/38ec8bf0-c1de-492c-af67-3a1df4c09d1c) | ![image](https://github.com/user-attachments/assets/00fa847e-9110-45da-9f53-78d3e780cd3d) |
