### PR TITLE
fix: compile styled-jsx in apps

### DIFF
--- a/cli/config/makeBabelConfig.js
+++ b/cli/config/makeBabelConfig.js
@@ -15,9 +15,36 @@ const getBabelModuleType = (moduleType) => {
             return false
     }
 }
-const makeBabelConfig = ({ moduleType, mode }) => {
+const makeBabelConfig = ({ moduleType, mode, isAppType }) => {
     const isTest = mode === 'test'
 
+    const styledJsxConfig = {
+        env: {
+            production: {
+                plugins: [
+                    [require('styled-jsx/babel'), { optimizeForSpeed: true }],
+                ],
+            },
+            development: {
+                plugins: [
+                    [require('styled-jsx/babel'), { optimizeForSpeed: true }],
+                ],
+            },
+            test: {
+                plugins: [require('styled-jsx/babel-test')],
+            },
+        },
+    }
+
+    // Minimal transpiling for apps
+    if (isAppType) {
+        return {
+            presets: ['@babel/preset-typescript'],
+            ...styledJsxConfig,
+        }
+    }
+
+    // More for libs
     return {
         presets: [
             require('@babel/preset-react'),
@@ -53,21 +80,7 @@ const makeBabelConfig = ({ moduleType, mode }) => {
             // Adds support for default value using ?? operator
             require('@babel/plugin-proposal-nullish-coalescing-operator'),
         ],
-        env: {
-            production: {
-                plugins: [
-                    [require('styled-jsx/babel'), { optimizeForSpeed: true }],
-                ],
-            },
-            development: {
-                plugins: [
-                    [require('styled-jsx/babel'), { optimizeForSpeed: true }],
-                ],
-            },
-            test: {
-                plugins: [require('styled-jsx/babel-test')],
-            },
-        },
+        ...styledJsxConfig,
     }
 }
 

--- a/cli/src/lib/compiler/compile.js
+++ b/cli/src/lib/compiler/compile.js
@@ -94,7 +94,9 @@ const compile = async ({
         fs.copySync(paths.shellSourcePublic, paths.shellPublic)
     }
 
-    const babelConfig = makeBabelConfig({ moduleType, mode })
+    const babelConfig = makeBabelConfig({ moduleType, mode, isAppType })
+
+    console.log({ babelConfig })
 
     const copyFile = async (source, destination) => {
         reporter.debug(
@@ -112,18 +114,20 @@ const compile = async ({
                     babelConfig
                 )
 
-                // Always write .js files
-                const jsDestination = normalizeExtension(destination)
+                // Always write .js files for libraries; don't change for apps
+                const resolvedDestination = isAppType
+                    ? destination
+                    : normalizeExtension(destination)
 
                 reporter.debug(
                     `Compiled ${prettyPrint.relativePath(
                         source
                     )} with Babel, saving to ${prettyPrint.relativePath(
-                        jsDestination
+                        resolvedDestination
                     )}`
                 )
 
-                await fs.writeFile(jsDestination, result.code)
+                await fs.writeFile(resolvedDestination, result.code)
             } catch (err) {
                 reporter.dumpErr(err)
                 reporter.error(
@@ -143,7 +147,7 @@ const compile = async ({
             outputDir: outDir,
             // todo: handle lib compilations with Vite
             // https://dhis2.atlassian.net/browse/LIBS-722
-            processFileCallback: isAppType ? copyFile : compileFile,
+            processFileCallback: compileFile,
             watch,
         }),
         isAppType &&


### PR DESCRIPTION
May be needed for Vite, which seems to have changed how styled-jsx is processed, even though the Vite config uses:

```js
plugins: [react({ babel: { plugins: ['styled-jsx/babel'] }})]
```