### PR TITLE
fix(plugin-pwa): fix pwa installations and plugins in global shell

### DIFF
--- a/pwa/src/service-worker/set-up-service-worker.js
+++ b/pwa/src/service-worker/set-up-service-worker.js
@@ -69,6 +69,8 @@ export function setUpServiceWorker() {
         const indexHtmlManifestEntry = precacheManifest.find(({ url }) =>
             url.endsWith('index.html')
         )
+        // Make sure that this request doesn't redirect to a global shell
+        indexHtmlManifestEntry.url += '?redirect=false'
         precache([indexHtmlManifestEntry])
 
         // Custom strategy for handling app navigation, specifically to allow
@@ -99,7 +101,8 @@ export function setUpServiceWorker() {
             // Return true to signal that we want to use the handler.
             return true
         }
-        const indexUrl = process.env.PUBLIC_URL + '/index.html'
+        // Above, the index entry had the redirect param added:
+        const indexUrl = process.env.PUBLIC_URL + '/index.html?redirect=false'
         const navigationRouteHandler = ({ request }) => {
             return fetch(request)
                 .then((response) => {

--- a/shell/src/PluginLoader.jsx
+++ b/shell/src/PluginLoader.jsx
@@ -196,7 +196,7 @@ export const PluginLoader = ({ config, requiredProps, D2App }) => {
     useEffect(() => {
         // make first request for props to communicate that iframe is ready
         postRobot
-            .send(window.top, 'getPropsFromParent')
+            .send(window.parent, 'getPropsFromParent')
             .then(receivePropsFromParent)
             .catch((err) => {
                 console.error(err)
@@ -207,7 +207,7 @@ export const PluginLoader = ({ config, requiredProps, D2App }) => {
         // set up listener to listen for subsequent sends from parent window
         const listener = postRobot.on(
             'updated',
-            { window: window.top },
+            { window: window.parent },
             (event) => {
                 receivePropsFromParent(event)
             }


### PR DESCRIPTION
[LIBS-762](https://dhis2.atlassian.net/browse/LIBS-762)
Would also contribute to [DHIS2-19160](https://dhis2.atlassian.net/browse/DHIS2-19160), but that can be handled on the back-end

1. Fixes correct `post-robot` target for plugins
2. ~Avoids getting redirected to Global Shell files instead of app files for `index.html` requests by the service worker~ -- dropped here in favor of a back-end fix

Tested by patching in the Data Visualizer app on the [Vite branch](https://github.com/dhis2/data-visualizer-app/pull/3266) -- before:

https://github.com/user-attachments/assets/41321339-0d92-4781-924a-0f1c6c2df8d7


After:

https://github.com/user-attachments/assets/971eec74-6e33-4e48-9636-8e2897bff784




[LIBS-762]: https://dhis2.atlassian.net/browse/LIBS-762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DHIS2-19160]: https://dhis2.atlassian.net/browse/DHIS2-19160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ