### PR TITLE
feat: extract and generate translation strings for manifest

### DIFF
--- a/cli/src/commands/build.js
+++ b/cli/src/commands/build.js
@@ -92,12 +92,15 @@ const handler = async ({
             }
 
             reporter.info('Generating internationalization strings...')
+
+            // extracting the po and pot files from src/ to i18n folder
             await i18n.extract({
                 input: paths.src,
                 output: paths.i18nStrings,
                 paths,
             })
-            await i18n.generate({
+
+            const { manifestTranslations } = await i18n.generate({
                 input: paths.i18nStrings,
                 output: paths.i18nLocales,
                 namespace: 'default',
@@ -150,6 +153,16 @@ const handler = async ({
                     allowJsxInJs,
                 })
                 await build(viteConfig)
+
+                const translationsPath = path.join(
+                    paths.shellBuildOutput,
+                    'manifest.webapp.translations.json'
+                )
+                fs.writeFileSync(
+                    translationsPath,
+                    JSON.stringify(manifestTranslations, null, 2),
+                    { encoding: 'utf8' }
+                )
 
                 if (config.pwa?.enabled) {
                     reporter.info('Compiling service worker...')


### PR DESCRIPTION
This PR extracts and generates pot files for translations based on the manifest files. Right now, it extracts: App title, description and the names of the shortcuts.

Some design decisions:
- the key names are prefixed with `__MANIFEST_` to minimise the chance of a collision with an app translation key - they are also suffixed with a _context_ string to make it easier to understand where they are used in Transifex 
- the file generated is named `manifest.webapp.translations.json` and lives next to `manifest.webapp`
- the JSON format is an array of objects with an ID for the language, and a dictionary for the translation strings (after removing the `__MANIFEST_` prefix and the context suffix. This format just makes it easier to hydrate into a Java object on the server-side.

Sample pot file with the strings extracted from d2.config
![image](https://github.com/user-attachments/assets/71070e41-3426-4caf-a6bd-08c9425816be)


Sample generated translation file:

```json
[
    {
        "locale": "ar",
        "translations": {}
    },
    {
        "locale": "ar_IQ",
        "translations": {}
    },
    {
        "locale": "en",
        "translations": {
            "APP_TITLE": "App Management",
            "APP_DESCRIPTION": "The Application Management App provides the ability to upload webapps in .zip files, as well as installing apps directly from the official DHIS 2 App Store",
            "SHORTCUT_All apps": "All apps",
            "SHORTCUT_App hub": "App hub"
        }
    },
    {
        "locale": "es",
        "translations": {
            "APP_TITLE": "(Spanish) App Management",
            "APP_DESCRIPTION": "(Spanish) The Application Management App provides the ability to upload webapps in .zip files, as well as installing apps directly from the official DHIS 2 App Store",
            "SHORTCUT_All apps": "(Spanish) All apps",
            "SHORTCUT_App hub": "(Spanish) App hub"
        }
    }
]

```