### PR TITLE
fix(pwa): ensure service worker registration triggers on page load

### DIFF
--- a/pwa/src/lib/registration.js
+++ b/pwa/src/lib/registration.js
@@ -160,7 +160,7 @@ export function register(config) {
             return
         }
 
-        window.addEventListener('load', () => {
+        const handleLoad = () => {
             // By compiling the dev SW to the 'public' dir, this URL works in
             // both dev and production modes
             const swUrl = new URL('service-worker.js', publicUrl)
@@ -182,7 +182,15 @@ export function register(config) {
                 // Is not localhost. Just register service worker
                 registerValidSW(swUrl, config)
             }
-        })
+        }
+
+        // Wait until assets have loaded to avoid bogging down network with
+        // precache requests
+        if (document.readyState === 'complete') {
+            handleLoad()
+        } else {
+            window.addEventListener('load', handleLoad)
+        }
     }
 }
 


### PR DESCRIPTION
If `register()` is called after the window `load` event, then the service worker won't get registered. This change checks for the [document ready state](https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState) to check if it's loaded already