### PR TITLE
fix: set default target for links to _top so they work in global shell

### DIFF
--- a/shell/public/index.html
+++ b/shell/public/index.html
@@ -59,6 +59,11 @@
             Learn how to configure a non-root public URL by running `npm run build`.
         -->
         <title>%REACT_APP_DHIS2_APP_NAME% | DHIS2</title>
+
+        <!-- 
+            By default, links without a target will navigate the top window.
+            This benefits plugins and apps hosted by a global shell
+        -->
         <base target="_top" />
     </head>
     <body>

--- a/shell/public/index.html
+++ b/shell/public/index.html
@@ -59,6 +59,7 @@
             Learn how to configure a non-root public URL by running `npm run build`.
         -->
         <title>%REACT_APP_DHIS2_APP_NAME% | DHIS2</title>
+        <base target="_top" />
     </head>
     <body>
         <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/shell/public/plugin.html
+++ b/shell/public/plugin.html
@@ -9,6 +9,12 @@
         <!-- Injection point for base URL from backend -->
         <meta name="dhis2-base-url" content="__DHIS2_BASE_URL__" />
         <title>Plugin</title>
+
+        <!-- 
+            By default, links without a target will navigate the top window.
+            This benefits plugins and apps hosted by a global shell
+        -->
+        <base target="_top" />
     </head>
     <body>
         <noscript>You need to enable JavaScript to run this plugin.</noscript>


### PR DESCRIPTION
I ended up going for `_top` since this mirrors the normal default `_self` as closely as possible (more closely than `_blank`).