### PR TITLE
fix: add headers to prevent avoid faulty redirects to global shell [11.x]

### DIFF
--- a/pwa/src/service-worker/set-up-service-worker.js
+++ b/pwa/src/service-worker/set-up-service-worker.js
@@ -108,7 +108,15 @@ export function setUpServiceWorker() {
         // Above, the index entry had the redirect param added:
         const indexUrl = process.env.PUBLIC_URL + '/index.html?redirect=false'
         const navigationRouteHandler = ({ request }) => {
-            return fetch(request)
+            let requestToUse = request
+            // If in an iframe, set custom header to let the backend know not to
+            // redirect this request to the global shell
+            if (request.destination === 'iframe') {
+                const newHeaders = new Headers(request.headers)
+                newHeaders.append('X-Requested-With', 'iframe')
+                requestToUse = new Request(request, { headers: newHeaders })
+            }
+            return fetch(requestToUse)
                 .then((response) => {
                     if (response.type === 'opaqueredirect' || !response.ok) {
                         // It's sending a redirect to the login page,


### PR DESCRIPTION
Part of [DHIS2-19412](https://dhis2.atlassian.net/browse/DHIS2-19412)

Adds `X-Requested-With = iframe` header, but by creating the request in the service worker itself, it also results in `Referer = .../service-worker.js`, which is convenient.

Some other details of the request are changed too, as shown by this table, but I think they're okay:
![Screenshot 2025-04-07 at 17 16 30](https://github.com/user-attachments/assets/4ede9cc6-5459-4b76-865f-19e9805ea556)



Before:
![Screenshot 2025-04-07 at 14 45 07](https://github.com/user-attachments/assets/e74d59f1-e20b-4274-946b-a70eb83282e4)


After:
<img width="1586" alt="Screenshot 2025-04-07 at 21 59 06" src="https://github.com/user-attachments/assets/c76f704c-1d84-473e-9c80-6e2a05e8c1b9" />

