### PR TITLE
fix(shell): add html base element for link targets

### DIFF
--- a/shell/index.html
+++ b/shell/index.html
@@ -54,7 +54,7 @@
             By default, links without a target will navigate the top window.
             This benefits plugins and apps hosted by a global shell
         -->
-        <base target="_top" />
+        <base target="_blank" />
     </head>
     <body>
         <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/shell/plugin.html
+++ b/shell/plugin.html
@@ -14,7 +14,7 @@
             By default, links without a target will navigate the top window.
             This benefits plugins and apps hosted by a global shell
         -->
-        <base target="_top" />
+        <base target="_blank" />
     </head>
     <body>
         <noscript>You need to enable JavaScript to run this plugin.</noscript>


### PR DESCRIPTION
[LIBS-765](https://dhis2.atlassian.net/browse/LIBS-765)

Apps using this HTML will open links in a new tab, instead of trying to open them inside the Global Shell and potentially failing for external links.

In 11.x, [we used `_top`](https://github.com/dhis2/app-platform/pull/916) for the base target, but I think it makes sense to move to `_blank` while we move toward sandboxing apps/iframes, which will block top-level navigation.

More discussion: [comment](https://dhis2.atlassian.net/browse/LIBS-765?focusedCommentId=211976)

[LIBS-765]: https://dhis2.atlassian.net/browse/LIBS-765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ