### PR TITLE
fix(lib-build): handle .jsx extensions in lib builds

### DIFF
--- a/cli/src/lib/compiler/extensionHelpers.js
+++ b/cli/src/lib/compiler/extensionHelpers.js
@@ -1,5 +1,16 @@
-const extensionPattern = /\.[jt]sx?$/
-const normalizeExtension = (ext) => ext.replace(extensionPattern, '.js')
+const extensionPattern = /\.([jt])sx?$/
+const normalizeExtension = (path) => {
+    const match = path.match(extensionPattern)
+    if (match[1] === 't') {
+        // This is a .ts or .tsx file - convert to .js,
+        // since imports should omit extensions in TS files
+        return path.replace(extensionPattern, '.js')
+    }
+
+    // For .js or .jsx files, leave as-is
+    // (though actual JSX will still get transpiled by babel)
+    return path
+}
 
 module.exports.extensionPattern = extensionPattern
 module.exports.normalizeExtension = normalizeExtension

--- a/cli/src/lib/compiler/extensionHelpers.test.js
+++ b/cli/src/lib/compiler/extensionHelpers.test.js
@@ -1,0 +1,11 @@
+const { normalizeExtension } = require('./extensionHelpers.js')
+
+test('it converts filenames with .ts or .tsx extensions to .js extensions', () => {
+    expect(normalizeExtension('filename.ts')).toBe('filename.js')
+    expect(normalizeExtension('filename.tsx')).toBe('filename.js')
+})
+
+test('it leaves filenames with .js or .jsx extensions as-is', () => {
+    expect(normalizeExtension('filename.js')).toBe('filename.js')
+    expect(normalizeExtension('filename.jsx')).toBe('filename.jsx')
+})

--- a/examples/simple-app/i18n/en.pot
+++ b/examples/simple-app/i18n/en.pot
@@ -5,11 +5,19 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-10-02T21:55:28.107Z\n"
-"PO-Revision-Date: 2019-10-02T21:55:28.107Z\n"
+"POT-Creation-Date: 2025-06-16T09:46:24.381Z\n"
+"PO-Revision-Date: 2025-06-16T09:46:24.381Z\n"
 
 msgid "Hello {{name}}"
-msgstr ""
+msgstr "Hello {{name}}"
 
 msgid "Have a great {{dayOfTheWeek}}!"
-msgstr ""
+msgstr "Have a great {{dayOfTheWeek}}!"
+
+msgctxt "Application title"
+msgid "__MANIFEST_APP_TITLE"
+msgstr "Simple Example App"
+
+msgctxt "Application description"
+msgid "__MANIFEST_APP_DESCRIPTION"
+msgstr "This is a simple example application"


### PR DESCRIPTION
[LIBS-772](https://dhis2.atlassian.net/browse/LIBS-772)

I tested this out by renaming some the files in the App Adapter lib in the repo, building it, then running the simple example app

**Before:**
| Filename | Imported as | Works? |
| --- | --- | --- |
| `ConnectedHeaderBar.jsx` | `'./ConnectedHeaderBar.jsx'` | ❌ |

<img width="1086" alt="Screenshot 2025-06-16 at 11 53 01" src="https://github.com/user-attachments/assets/a043f6bd-3070-4412-a20f-4689f87d8334" />


**After:**

| Filename | Imported as | Works? |
| --- | --- | --- |
| `ConnectedBar.jsx` | `'./ConnectedHeaderBar.jsx'` | ✅ |
| `ConnectedHeaderBar.tsx` | `'./ConnectedHeaderBar'` | ✅  |