### PR TITLE
fix: update manifest tranlsations file format

### DIFF
--- a/cli/src/commands/build.js
+++ b/cli/src/commands/build.js
@@ -98,6 +98,7 @@ const handler = async ({
                 input: paths.src,
                 output: paths.i18nStrings,
                 paths,
+                isApp: isApp(config.type),
             })
 
             const { manifestTranslations } = await i18n.generate({

--- a/cli/src/lib/i18n/extract.js
+++ b/cli/src/lib/i18n/extract.js
@@ -6,7 +6,7 @@ const scanner = require('i18next-scanner')
 const parseConfig = require('../parseConfig')
 const { checkDirectoryExists, walkDirectory, arrayEqual } = require('./helpers')
 
-const extract = async ({ input, output, paths }) => {
+const extract = async ({ input, output, paths, isApp }) => {
     const relativeInput = './' + path.relative(paths.base, input)
     if (!checkDirectoryExists(input)) {
         reporter.error(
@@ -67,22 +67,24 @@ const extract = async ({ input, output, paths }) => {
      * msgid "__MANIFEST_SHORTCUT_Apps Home"
      * msgstr "Apps Home"
      */
-    try {
-        reporter.debug(
-            'Extracting manifest strings (title, description and shortcuts) for translation'
-        )
-        const configContents = parseConfig(paths)
-        en['__MANIFEST_APP_TITLE_Application title'] = configContents.title
-        en['__MANIFEST_APP_DESCRIPTION_Application description'] =
-            configContents.description
-        configContents.shortcuts?.forEach((shortcut) => {
-            en[
-                `__MANIFEST_SHORTCUT_${shortcut?.name}_Title for shortcut used by command palette`
-            ] = shortcut?.name
-        })
-    } catch (err) {
-        reporter.warn('error extracting manifest translations strings')
-        reporter.warn(err)
+    if (isApp) {
+        try {
+            reporter.debug(
+                'Extracting manifest strings (title, description and shortcuts) for translation'
+            )
+            const configContents = parseConfig(paths)
+            en['__MANIFEST_APP_TITLE_Application title'] = configContents.title
+            en['__MANIFEST_APP_DESCRIPTION_Application description'] =
+                configContents.description
+            configContents.shortcuts?.forEach((shortcut) => {
+                en[
+                    `__MANIFEST_SHORTCUT_${shortcut?.name}_Title for shortcut used by command palette`
+                ] = shortcut?.name
+            })
+        } catch (err) {
+            reporter.warn('error extracting manifest translations strings')
+            reporter.warn(err)
+        }
     }
 
     if (Object.keys(en).length === 0) {

--- a/cli/src/lib/i18n/generate.js
+++ b/cli/src/lib/i18n/generate.js
@@ -83,17 +83,23 @@ const generate = async ({ input, output, namespace, paths }) => {
              */
             const manifestTranslation = {
                 locale: lang,
-                translations: {},
+                shortcuts: {},
             }
 
             try {
                 for (const [key, value] of Object.entries(JSON.parse(json))) {
-                    if (key.match(/__MANIFEST_/)) {
+                    if (key.match(/__MANIFEST_SHORTCUT_/)) {
                         // removing the initial prefix and the context description at the end of the key
                         const keyCleaned = key
-                            ?.replace(/__MANIFEST_/, '')
+                            ?.replace(/__MANIFEST_SHORTCUT_/, '')
                             .replace(/_[^_]+$/, '')
-                        manifestTranslation.translations[keyCleaned] = value
+                        manifestTranslation.shortcuts[keyCleaned] = value
+                    }
+                    if (key.match(/__MANIFEST_APP_/)) {
+                        const keyCleaned = key
+                            ?.replace(/__MANIFEST_APP_/, '')
+                            .replace(/_[^_]+$/, '')
+                        manifestTranslation[keyCleaned?.toLowerCase()] = value
                     }
                 }
             } catch (err) {


### PR DESCRIPTION
updates the format of the `manifest.web.translations` file generated for manifest translations.

related to https://github.com/dhis2/dhis2-core/pull/20246
implements https://dhis2.atlassian.net/browse/DHIS2-19189

## Before

```
[
  {
    "locale": "en",
    "translations": {
      "APP_TITLE": "Route Manager 1",
      "APP_DESCRIPTION": "An app to manage route through the Route API",
      "SHORTCUT_create a s": "create a s",
      "SHORTCUT_list": "list"
    }
  },
  {
    "locale": "fr",
    "translations": {
      "APP_TITLE": "Le Route Manager",
      "APP_DESCRIPTION": "",
      "SHORTCUT_create": "Creer"
    }
  }
]
```

## After

```
[
  {
    "locale": "en",
    "shortcuts": {
      "create a s": "create a s",
      "list": "list"
    },
    "title": "Route Manager",
    "description": ""
  },
  {
    "locale": "fr",
    "shortcuts": {
      "create": "Creer"
    },
    "title": "Le Route Manager",
    "description": ""
  }
]
```