### PR TITLE
docs(vite-config): fix filename annotations on codeblock

### DIFF
--- a/docs/config/extending-vite-config.md
+++ b/docs/config/extending-vite-config.md
@@ -25,7 +25,7 @@ The config file uses an `.mjs` extension so that it can import the `defineConfig
 If you're using TypeScript, you can use an `.mts` extension.
 :::
 
-```js filename='viteConfigExtensions.mjs'
+```js title='viteConfigExtensions.mjs'
 import path from 'path'
 import { defineConfig } from 'vite'
 
@@ -49,7 +49,7 @@ Add the path to your Vite config file as the value to `viteConfigExtensions` in 
 
 The path can be relative or absolute. If it's relative, it will be resolved relative to the current working directory, or the location provided to the `cwd` option when running the script.
 
-```js filename='d2.config.js'
+```js title='d2.config.js'
 const config = {
     name: 'simple-app',
     direction: 'auto',
@@ -70,7 +70,7 @@ module.exports = config
 
 The object should match Vite's [`UserConfig` interface](https://vite.dev/config/#config-intellisense).
 
-```js filename='d2.config.js'
+```js title='d2.config.js'
 const config = {
     name: 'simple-app',
     direction: 'auto',


### PR DESCRIPTION
When the annotation is correct, it adds a little header above the code block -- I had the wrong annotation. Here's what it looks like, manually editing it to `title` in the Developer Portal repo:

<img width="1019" height="702" alt="Screenshot 2025-07-29 at 15 27 37" src="https://github.com/user-attachments/assets/afb57adc-aab8-4cb7-8104-9deeddfd09a3" />
