### PR TITLE
fix(cli): avoid symlink error

### DIFF
--- a/cli/src/lib/bootstrapShell.js
+++ b/cli/src/lib/bootstrapShell.js
@@ -66,7 +66,7 @@ const bootstrapShell = async ({ paths, shell, force = false }) => {
 
     const srcNodeModules = path.join(source, 'node_modules')
     const destNodeModules = path.join(dest, 'node_modules')
-    if (fs.exists(srcNodeModules)) {
+    if (fs.existsSync(srcNodeModules)) {
         reporter.debug(
             `Linking ${path.relative(
                 paths.base,


### PR DESCRIPTION
[LIBS-781](https://dhis2.atlassian.net/browse/LIBS-781)

Fixes this error (before):

<img width="678" height="805" alt="Screenshot 2025-08-11 at 14 38 26" src="https://github.com/user-attachments/assets/105e9f03-8425-4719-9f2e-394544aec4b9" />

After:

<img width="678" height="805" alt="Screenshot 2025-08-11 at 14 40 59" src="https://github.com/user-attachments/assets/4acef0cd-2f54-4688-af6d-71f7d3cc26d5" />



[LIBS-781]: https://dhis2.atlassian.net/browse/LIBS-781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ