### PR TITLE
feat: add babel support for private class properties and methods using # prefix

### DIFF
--- a/cli/config/makeBabelConfig.js
+++ b/cli/config/makeBabelConfig.js
@@ -52,6 +52,10 @@ const makeBabelConfig = ({ moduleType, mode }) => {
 
             // Adds support for default value using ?? operator
             require('@babel/plugin-transform-nullish-coalescing-operator'),
+
+            // Adds support for private class properties and methods using # prefix
+            '@babel/plugin-transform-private-methods',
+            '@babel/plugin-transform-private-property-in-object',
         ],
         env: {
             production: {

--- a/cli/package.json
+++ b/cli/package.json
@@ -27,6 +27,8 @@
         "@babel/plugin-transform-class-properties": "^7.27.1",
         "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
         "@babel/plugin-transform-optional-chaining": "^7.27.1",
+        "@babel/plugin-transform-private-methods": "^7.27.1",
+        "@babel/plugin-transform-private-property-in-object": "^7.27.1",
         "@babel/preset-env": "^7.27.2",
         "@babel/preset-react": "^7.0.0",
         "@babel/preset-typescript": "^7.27.1",


### PR DESCRIPTION
Babel is still used by Jest, so if anyone produces any code with private class properties and methods and wants to add unit tests for it, then this will be useful.