### PR TITLE
fix: extract manifest translation strings on start command

### DIFF
--- a/cli/src/commands/start.js
+++ b/cli/src/commands/start.js
@@ -95,6 +95,7 @@ const handler = async ({
                 input: paths.src,
                 output: paths.i18nStrings,
                 paths,
+                isApp: isApp(config.type),
             })
             await i18n.generate({
                 input: paths.i18nStrings,


### PR DESCRIPTION
Fixes [LIBS-828](https://dhis2.atlassian.net/browse/LIBS-828)

-----------------

**Description**
Previously, the start command would extract and generate all the translatable strings without the app title, description and shortcuts. This PR adds the `isApp flag` just as is done in the `build` command during i18n extraction of strings. This pulls the app title, description and shortcuts from dhis2.config.js and adds them to the translatable strings. 

[LIBS-828]: https://dhis2.atlassian.net/browse/LIBS-828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ