### PR TITLE
fix(i18n): emit manifest strings from config in standalone extract

### DIFF
--- a/cli/src/commands/build.js
+++ b/cli/src/commands/build.js
@@ -102,7 +102,6 @@ const handler = async ({
                 input: paths.src,
                 output: paths.i18nStrings,
                 paths,
-                isApp: isApp(config.type),
             })
 
             const { manifestTranslations } = await i18n.generate({

--- a/cli/src/commands/start.js
+++ b/cli/src/commands/start.js
@@ -95,7 +95,6 @@ const handler = async ({
                 input: paths.src,
                 output: paths.i18nStrings,
                 paths,
-                isApp: isApp(config.type),
             })
             await i18n.generate({
                 input: paths.i18nStrings,

--- a/cli/src/lib/i18n/extract.js
+++ b/cli/src/lib/i18n/extract.js
@@ -6,7 +6,7 @@ const scanner = require('i18next-scanner')
 const parseConfig = require('../parseConfig')
 const { checkDirectoryExists, walkDirectory, arrayEqual } = require('./helpers')
 
-const extract = async ({ input, output, paths, isApp }) => {
+const extract = async ({ input, output, paths }) => {
     const relativeInput = './' + path.relative(paths.base, input)
     if (!checkDirectoryExists(input)) {
         reporter.error(
@@ -67,12 +67,12 @@ const extract = async ({ input, output, paths, isApp }) => {
      * msgid "__MANIFEST_SHORTCUT_Apps Home"
      * msgstr "Apps Home"
      */
-    if (isApp) {
+    const configContents = parseConfig(paths)
+    if (configContents.entryPoints?.app) {
         try {
             reporter.debug(
                 'Extracting manifest strings (title, description and shortcuts) for translation'
             )
-            const configContents = parseConfig(paths)
             en['__MANIFEST_APP_TITLE_Application title'] = configContents.title
             en['__MANIFEST_APP_DESCRIPTION_Application description'] =
                 configContents.description

--- a/cli/src/lib/i18n/extract.test.js
+++ b/cli/src/lib/i18n/extract.test.js
@@ -1,0 +1,72 @@
+jest.mock('i18next-conv')
+jest.mock('i18next-scanner')
+jest.mock('fs-extra')
+jest.mock('../parseConfig')
+jest.mock('./helpers')
+
+const fs = require('fs-extra')
+const { i18nextToPot } = require('i18next-conv')
+const scanner = require('i18next-scanner')
+const parseConfig = require('../parseConfig')
+const extract = require('./extract')
+const helpers = require('./helpers')
+
+const paths = { base: '/app', src: '/app/src' }
+
+// Grab the `en` object that extract serialises into the .pot file
+const getExtractedStrings = () => JSON.parse(i18nextToPot.mock.calls[0][1])
+
+beforeEach(() => {
+    jest.clearAllMocks()
+
+    helpers.checkDirectoryExists.mockReturnValue(true)
+    helpers.walkDirectory.mockReturnValue(['/app/src/App.js'])
+    helpers.arrayEqual.mockReturnValue(false)
+
+    fs.readFileSync.mockReturnValue('')
+    fs.existsSync.mockReturnValue(false)
+
+    i18nextToPot.mockResolvedValue('pot-content')
+
+    // Pretend the scanner always finds one regular translation string so that
+    // `en` is never empty and extract always reaches the .pot write step
+    scanner.Parser.mockImplementation(() => ({
+        parseFuncFromString: () => ({ get: () => undefined }),
+        get: () => ({ en: { translation: { Hello: 'Hello' } } }),
+    }))
+})
+
+describe('i18n extract', () => {
+    it('emits manifest strings when the config has an app entry point', async () => {
+        parseConfig.mockReturnValue({
+            title: 'My App',
+            description: 'My App description',
+            shortcuts: [{ name: 'Apps Home' }],
+            entryPoints: { app: './src/App' },
+        })
+
+        await extract({ input: paths.src, output: '/app/i18n', paths })
+
+        const en = getExtractedStrings()
+        expect(en).toMatchObject({
+            '__MANIFEST_APP_TITLE_Application title': 'My App',
+            '__MANIFEST_APP_DESCRIPTION_Application description':
+                'My App description',
+            '__MANIFEST_SHORTCUT_Apps Home_Title for shortcut used by command palette':
+                'Apps Home',
+        })
+    })
+
+    it('does not emit manifest strings when the config has no app entry point', async () => {
+        parseConfig.mockReturnValue({
+            title: 'My Lib',
+            description: 'My Lib description',
+            entryPoints: { lib: './src/index' },
+        })
+
+        await extract({ input: paths.src, output: '/app/i18n', paths })
+
+        const en = getExtractedStrings()
+        expect(Object.keys(en)).toEqual(['Hello'])
+    })
+})


### PR DESCRIPTION
## Problem

`d2-app-scripts i18n extract` produced a different `i18n/en.pot` than `build` and `start`, because it dropped the `__MANIFEST_APP_*` / `__MANIFEST_SHORTCUT_*` strings.

All three call `extract()`, which only emitted those strings inside `if (isApp)`. `build` and `start` passed `isApp`; the standalone `i18n` command didn't.

## Fix

`extract()` now decides from the config it already parses — emitting the manifest strings when `config.entryPoints?.app` is present — instead of a caller-supplied flag. The redundant `isApp` argument is removed from `extract` and its call sites. All three paths now emit the same strings.

## Tests

Added `src/lib/i18n/extract.test.js`: manifest strings are emitted iff the config has an app entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

fixes https://dhis2.atlassian.net/browse/LIBS-828 